### PR TITLE
 feat(training): Implement Early Stopping to prevent overfitting

### DIFF
--- a/configs/prediction_defaults.yaml
+++ b/configs/prediction_defaults.yaml
@@ -27,7 +27,7 @@ dropout_rate: 0.2
 
 # --- Training Process ---
 # The total number of epochs to train the model.
-epochs: 100
+epochs: 1000
 
 # The number of samples per gradient update.
 batch_size: 32
@@ -38,3 +38,18 @@ verbose: 1
 # The interval in epochs at which to save model checkpoints.
 # Set to null or remove the line to disable periodic checkpointing and only save the final model.
 checkpoint_interval: 20
+
+# Early stopping settings
+early_stopping_patience: 100
+early_stopping_monitor: 'val_loss'
+early_stopping_min_delta: 0.00001
+
+
+# Defines the upper boundaries of box office ranges for classification-based metrics.
+# Example: [1_000_000, 10_000_000, 90_000_000] creates 4 classes.
+box_office_ranges: [1000000, 10000000, 90000000]
+
+# The averaging method for F1 score calculation (e.g., 'binary', 'macro', 'weighted').
+# 'macro' is recommended for multi-class problems to treat all classes equally.
+f1_average_method: 'macro'
+

--- a/src/cli/argument_parser_builder.py
+++ b/src/cli/argument_parser_builder.py
@@ -200,6 +200,40 @@ class ArgumentParserBuilder:
             '--checkpoint-interval', type=int, required=False, help='Override the model checkpoint interval.'
         )
 
+        params_override_group.add_argument(
+            '--early-stopping-patience',
+            type=int,
+            required=False,
+            help='Override the patience for early stopping.'
+        )
+        params_override_group.add_argument(
+            '--early-stopping-monitor',
+            type=str,
+            required=False,
+            help="Override the metric to monitor for early stopping (e.g., 'val_loss', 'val_f1_score')."
+        )
+        params_override_group.add_argument(
+            '--early-stopping-min-delta',
+            type=float,  # Explicitly define the type as float
+            required=False,
+            help='Override the minimum delta for early stopping (e.g., 1e-5).'
+        )
+        params_override_group.add_argument(
+            '--box-office-ranges',
+            type=int,
+            nargs='+',  # Allows multiple integer values
+            metavar='RANGE',
+            required=False,
+            help="Override the box office ranges for F1 score calculation (e.g., --box-office-ranges 1000000 10000000)."
+        )
+        params_override_group.add_argument(
+            '--f1-average-method',
+            type=str,
+            choices=['macro', 'micro', 'weighted', 'binary'],
+            required=False,
+            help="Override the averaging method for F1 score ('macro', 'micro', 'weighted', 'binary')."
+        )
+
         continue_group = parser.add_argument_group(
             'Continue Training (Optional)',
             description='Options to continue training from a previously saved checkpoint. '

--- a/src/data_handling/movie_collections.py
+++ b/src/data_handling/movie_collections.py
@@ -5,7 +5,7 @@ from logging import Logger
 from pathlib import Path
 from typing import Final, Literal, Optional, Type, TypeAlias, TypeVar
 
-import numpy as np
+from numpy import mean
 
 from src.core.logging_manager import LoggingManager
 from src.data_handling.box_office import BoxOffice, BoxOfficeRawData, BoxOfficeSerializableData
@@ -93,7 +93,7 @@ class WeekData:
         # noinspection PyTypeChecker
         scores: list[float] = [review.sentiment_score for review in chain(self.public_reviews, self.expert_reviews) if
                                review.sentiment_score is not None]
-        return float(np.mean(scores)) if scores else None
+        return float(mean(scores)) if scores else None
 
     @property
     def average_expert_score(self) -> Optional[float]:
@@ -105,7 +105,7 @@ class WeekData:
         :return: The average expert score, or None if no expert reviews are available.
         """
         scores: list[float] = [review.expert_score for review in self.expert_reviews]
-        return float(np.mean(scores)) if scores else None
+        return float(mean(scores)) if scores else None
 
     @property
     def total_reply_count(self) -> int:

--- a/src/models/base/base_evaluator.py
+++ b/src/models/base/base_evaluator.py
@@ -180,7 +180,7 @@ class BaseEvaluator(
         :returns: A tuple containing the training loss list and validation loss list.
         :raises FileNotFoundError: If the history file does not exist.
         """
-        self.logger.info(f"Step 2: Loading training history from '{history_file_path}'...")
+        self.logger.info(f"Loading training history from '{history_file_path}'...")
         if not history_file_path.exists():
             raise FileNotFoundError(f"Training history file not found at: {history_file_path}")
 
@@ -220,7 +220,7 @@ class BaseEvaluator(
         x_test, y_test = self._prepare_test_data(data_processor=data_processor, config=config)
 
         # Calculate all metrics (delegated to subclass)
-        self.logger.info("Step 4: Calculating requested metrics on the test set...")
+        self.logger.info("Calculating requested metrics on the test set...")
         calculated_metrics = self._calculate_metrics(
             model_core=model_core,
             data_processor=data_processor,
@@ -230,7 +230,7 @@ class BaseEvaluator(
         )
 
         # Compile final result (delegated to subclass)
-        self.logger.info("Step 5: Compiling final evaluation results...")
+        self.logger.info("Compiling final evaluation results...")
         final_result = self._compile_final_result(
             config=config,
             metrics=calculated_metrics,

--- a/src/models/base/base_evaluator.py
+++ b/src/models/base/base_evaluator.py
@@ -173,14 +173,25 @@ class BaseEvaluator(
         """
         Loads the training and validation loss history from a pickle file.
 
+        This method now correctly handles loading a dictionary that was saved
+        from a Keras History object's `.history` attribute.
+
         :param history_file_path: The path to the history file.
         :returns: A tuple containing the training loss list and validation loss list.
+        :raises FileNotFoundError: If the history file does not exist.
         """
         self.logger.info(f"Step 2: Loading training history from '{history_file_path}'...")
-        history: History = PickleFile(path=history_file_path).load()
-        training_loss: list[float] = history.history.get('loss', [])
-        validation_loss: list[float] = history.history.get('val_loss', [])
+        if not history_file_path.exists():
+            raise FileNotFoundError(f"Training history file not found at: {history_file_path}")
+
+        history_dict: dict[str, list[float]] = PickleFile(path=history_file_path).load()
+
+        # Directly access the keys from the loaded dictionary.
+        training_loss: list[float] = history_dict.get('loss', [])
+        validation_loss: list[float] = history_dict.get('val_loss', [])
+
         return training_loss, validation_loss
+
 
     def run(self, config: EvaluationConfigType) -> EvaluationResultType:
         """

--- a/src/models/base/base_pipeline.py
+++ b/src/models/base/base_pipeline.py
@@ -7,10 +7,13 @@ from src.core.logging_manager import LoggingManager
 from src.data_handling.file_io import PickleFile
 from src.models.base.base_data_processor import BaseDataProcessor
 from src.models.base.base_model_core import BaseModelCore
+from src.models.base.callbacks import F1ScoreHistory
 from src.models.base.keras_setup import keras_base
 
 History = keras_base.callbacks.History
 ModelCheckpoint = keras_base.callbacks.ModelCheckpoint
+EarlyStopping = keras_base.callbacks.EarlyStopping
+Callback = keras_base.callbacks.Callback
 
 DataProcessorType = TypeVar('DataProcessorType', bound=BaseDataProcessor)
 ModelCoreType = TypeVar('ModelCoreType', bound=BaseModelCore)
@@ -144,33 +147,46 @@ class BaseTrainingPipeline(
         history_save_path: Path,
         continue_from_epoch: Optional[int],
         **kwargs: any
-    ) -> History:
+    ) -> dict[str, any]:
         """
         Merges a new training history with an existing one if applicable.
 
-        This base implementation handles the standard merging logic. Subclasses
-        can override this to add specific metrics (like F1 scores).
+        This implementation is enhanced to handle custom callback data, such as
+        F1 scores from an F1ScoreHistory callback, passed via kwargs.
 
         :param new_history: The History object from the latest training run.
         :param history_save_path: The path to the history file.
         :param continue_from_epoch: The epoch number the training continued from.
-        :param kwargs: Catches extra arguments passed from subclasses.
-        :returns: The final, potentially merged, History object to be saved.
+        :param kwargs: Catches extra arguments passed from subclasses, like 'f1_history_callback'.
+        :returns: The final, potentially merged, history dictionary to be saved.
         """
+        history_to_save: dict[str, any]
+
+        # The new_history.history object might not contain val_f1_score if it was never triggered
+        # in the first epoch. We should get it from the callback directly.
+        f1_history_callback: Optional[F1ScoreHistory] = kwargs.get('f1_history_callback')
+        if f1_history_callback:
+            new_history.history['val_f1_score'] = f1_history_callback.f1_scores
+
         if continue_from_epoch and history_save_path.exists():
             self.logger.info(f"Loading existing history from {history_save_path} to append new results.")
-            old_history: History = PickleFile(path=history_save_path).load()
+            old_history_data: dict[str, any] = PickleFile(path=history_save_path).load()
             for key, value in new_history.history.items():
-                old_history.history.setdefault(key, []).extend(value)
-            return old_history
+                if key not in old_history_data:
+                    old_history_data[key] = []
+                old_history_data[key].extend(value)
+            history_to_save = old_history_data
         else:
-            return new_history
+            history_to_save = new_history.history
+
+        return history_to_save
 
     def _save_run_artifacts(
         self,
         config: PipelineConfigType,
         history: History,
         artifacts_folder: Path,
+        callbacks: list[Callback],
         continue_from_epoch: Optional[int],
         **kwargs: any
     ) -> None:
@@ -178,39 +194,67 @@ class BaseTrainingPipeline(
         Handles the common logic for saving all artifacts at the end of a run.
 
         This template method saves the training history, data processor artifacts,
-        and the final model state.
+        and the final model state. It intelligently determines the correct epoch
+        number for the saved model, especially when EarlyStopping is used.
 
         :param config: The master configuration object for the run.
         :param history: The History object from the completed training.
         :param artifacts_folder: The root directory for model artifacts.
+        :param callbacks: The list of Keras callbacks used during training.
         :param continue_from_epoch: The epoch number the training continued from, if any.
         :param kwargs: Extra arguments to be passed to helper methods like _merge_histories.
         """
         self.logger.info("Saving all run artifacts...")
 
-        # Save History (delegating merging logic)
+        # Determine the correct final epoch for saving
+        final_epoch: int
+        early_stopping_callback: Optional[EarlyStopping] = next(
+            (cb for cb in callbacks if isinstance(cb, EarlyStopping)),  # Search in the provided list
+            None
+        )
+
+        if early_stopping_callback and early_stopping_callback.stopped_epoch > 0:
+            # Early stopping was triggered. The model weights were restored to the best epoch.
+            # The 'best_epoch' attribute is 0-indexed, so we add 1 for the filename.
+            final_epoch = early_stopping_callback.best_epoch + 1
+            self.logger.info(
+                f"Early stopping was triggered. The best model was at epoch {final_epoch}. "
+                f"Saving model with this epoch number."
+            )
+        else:
+            # Training completed all epochs without early stopping.
+            # The number of epochs run is the length of the 'loss' history list.
+            epochs_run: int = len(history.history.get('loss', []))
+            final_epoch = epochs_run + (continue_from_epoch or 0)
+            self.logger.info(
+                f"Training completed all configured epochs. Saving final model for epoch {final_epoch}."
+            )
+
+        # Save Final Model State
+        # We save the model that is currently in memory. If early stopping with
+        # restore_best_weights=True was used, this is the best model.
+        # We assume the config object has 'model_id'
+        model_id: str = getattr(config, 'model_id', 'model')
+        final_model_save_path: Path = artifacts_folder / f"{model_id}_{final_epoch:04d}.keras"
+        self.model_core.save(file_path=final_model_save_path)
+        self.logger.info(f"Final model state saved to: {final_model_save_path}")
+
+        # --- Save History ---
         history_filename: str = self.get_history_filename()
         history_save_path: Path = artifacts_folder / history_filename
-        history_to_save: History = self._merge_histories(
+        history_to_save: dict[str, any] = self._merge_histories(
             new_history=history,
             history_save_path=history_save_path,
-            continue_from_epoch=continue_from_epoch
+            continue_from_epoch=continue_from_epoch,
+            **kwargs
         )
         PickleFile(path=history_save_path).save(data=history_to_save)
         self.logger.info(f"Training history saved to: {history_save_path}")
 
-        # Save Data Processor Artifacts (only on a new run)
+        # --- Save Data Processor Artifacts (only on a new run) ---
         if not continue_from_epoch:
             self.data_processor.save_artifacts()
             self.logger.info(f"Data processor artifacts saved in: {self.data_processor.model_artifacts_path}")
-
-        # Save Final Model State (if not already saved by a checkpoint)
-        # We need to access model_id and epochs from the config, which requires a bit of care
-        # since PipelineConfigType is a generic. We assume it has these attributes.
-        final_model_save_path: Path = artifacts_folder / f"{config.model_id}_{config.epochs:04d}.keras"
-        if not final_model_save_path.exists():
-            self.model_core.save(file_path=final_model_save_path)
-            self.logger.info(f"Final model state for epoch {config.epochs} saved to: {final_model_save_path}")
 
     def _setup_checkpoint_callback(
         self,
@@ -265,3 +309,35 @@ class BaseTrainingPipeline(
         )
         return model_checkpoint_callback
 
+    def _setup_early_stopping_callback(self, config: PipelineConfigType) -> Optional[EarlyStopping]:
+        """
+        Sets up the EarlyStopping callback based on the pipeline configuration.
+
+        This helper method centralizes the logic for creating an early stopping
+        callback if it is enabled in the configuration.
+
+        :param config: The master configuration object for the run, which must
+                       have `early_stopping_patience`, `early_stopping_monitor`,
+                       and `early_stopping_min_delta` attributes.
+        :returns: A configured `EarlyStopping` instance if enabled, otherwise `None`.
+        """
+        patience: Optional[int] = getattr(config, 'early_stopping_patience', None)
+        if patience is None:
+            return None
+
+        monitor: str = getattr(config, 'early_stopping_monitor', 'val_loss')
+        min_delta: float = getattr(config, 'early_stopping_min_delta', 0.0)
+        mode: str = 'max' if 'f1' in monitor or 'accuracy' in monitor else 'auto'
+
+        self.logger.info(
+            f"Early stopping enabled: monitoring '{monitor}' with patience={patience}."
+        )
+        early_stopping_callback: EarlyStopping = EarlyStopping(
+            monitor=monitor,
+            patience=patience,
+            min_delta=min_delta,
+            verbose=1,
+            mode=mode,
+            restore_best_weights=True  # Always restore best weights
+        )
+        return early_stopping_callback

--- a/src/models/base/callbacks.py
+++ b/src/models/base/callbacks.py
@@ -1,8 +1,11 @@
+from typing import Optional
+
+from numpy import array
 from numpy.typing import NDArray
-from sklearn.metrics import f1_score
 from typing_extensions import override
 
 from src.models.base.keras_setup import keras_base
+from src.utilities.metrics import BaseClassificationMetrics
 
 Callback = keras_base.callbacks.Callback
 
@@ -10,38 +13,69 @@ Callback = keras_base.callbacks.Callback
 # noinspection PyOverrides
 class F1ScoreHistory(Callback):
     """
-    A Keras Callback to calculate and record the F1 score on validation data at the end of each epoch.
+    A Keras Callback to calculate and record classification metrics on validation data at the end of each epoch.
+
+    This callback uses a provided metrics calculator (an instance of a
+    BaseClassificationMetrics subclass) to perform the evaluation. This
+    decouples the callback from the specific metric calculation logic.
 
     :ivar validation_data: A tuple (x_val, y_val) containing the validation data.
+    :ivar metrics_calculator: An instance of a class that inherits from
+                              BaseClassificationMetrics, responsible for all
+                              metric calculations.
     :ivar f1_scores: A list that stores the computed F1 score for each epoch.
     """
+    validation_data: tuple[NDArray[any], NDArray[any]]
+    metrics_calculator: BaseClassificationMetrics
+    f1_scores: list[float]
 
     @override
-    def __init__(self, validation_data: tuple[NDArray[any], NDArray[any]]):
+    def __init__(
+        self,
+        *,
+        validation_data: tuple[NDArray[any], NDArray[any]],
+        metrics_calculator: BaseClassificationMetrics
+    ) -> None:
         """
         Initializes the F1ScoreHistory callback.
 
-        :param validation_data: A tuple (x_val, y_val) to be used for calculating the F1 score.
+        :param validation_data: A tuple (x_val, y_val) to be used for evaluation.
+        :param metrics_calculator: A pre-configured instance of a metrics
+                                   calculator (e.g., RegressionToClassificationMetrics).
         """
         super().__init__()
         self.validation_data: tuple[NDArray[any], NDArray[any]] = validation_data
+        self.metrics_calculator: BaseClassificationMetrics = metrics_calculator
         self.f1_scores: list[float] = []
 
     @override
-    def on_epoch_end(self, epoch: int, logs: dict[str, any] | None = None) -> None:
+    def on_epoch_end(self, epoch: int, logs: Optional[dict[str, any]] = None) -> None:
         """
         Called at the end of an epoch to compute and store the F1 score.
+
+        This method gets raw predictions from the model, delegates the metric
+        calculation to the `metrics_calculator`, and logs the resulting F1 score.
 
         :param epoch: The index of the current epoch.
         :param logs: Metric results for this training epoch, and for the validation epoch.
         """
-        x_val, y_val = self.validation_data
-        y_pred_probs: NDArray[any] = self.model.predict(x=x_val, verbose=0)
-        y_pred_labels: NDArray[any] = (y_pred_probs > 0.5).astype("int32")
+        x_val, y_val_scaled = self.validation_data
+        y_pred_scaled: NDArray[any] = self.model.predict(x=x_val, verbose=0)
 
-        score: float = f1_score(y_true=y_val, y_pred=y_pred_labels, average='binary', zero_division=0)
+        # The metrics framework expects NumPy arrays.
+        y_true_np: NDArray[any] = array(y_val_scaled)
+        y_pred_np: NDArray[any] = array(y_pred_scaled)
+
+        # Delegate the entire calculation process to the metrics calculator.
+        report: dict[str, any] = self.metrics_calculator.generate_report(
+            y_true=y_true_np,
+            y_pred=y_pred_np
+        )
+
+        # Extract the F1 score and store it.
+        score: float = report.get('f1_score', 0.0)
         self.f1_scores.append(score)
 
-        # Optionally, add it to the Keras logs so it's printed
+        # Optionally, add it to the Keras logs so it's printed and can be monitored.
         if logs is not None:
             logs['val_f1_score'] = score

--- a/src/models/base/data_splitter.py
+++ b/src/models/base/data_splitter.py
@@ -1,7 +1,7 @@
 from logging import Logger
 from typing import Generic, Optional, TypeVar
 
-import numpy as np
+from numpy import array, unique
 from numpy.typing import NDArray
 from sklearn.model_selection import train_test_split
 
@@ -162,7 +162,7 @@ class DatasetSplitter(Generic[X_Type, Y_Type]):
         :returns: True if the data can be stratified, False otherwise.
         """
         if y_data.ndim == 1:  # Typical for classification
-            _, counts = np.unique(y_data, return_counts=True)
+            _, counts = unique(y_data, return_counts=True)
             # Stratification requires at least 2 samples for each class present
             return all(count >= 2 for count in counts)
         return False  # Cannot stratify multidimensional or regression targets this way
@@ -182,6 +182,6 @@ class DatasetSplitter(Generic[X_Type, Y_Type]):
         """
         empty_x_shape = (0,) + x_ref.shape[1:] if x_ref.ndim > 1 else (0,)
         empty_y_shape = (0,) + y_ref.shape[1:] if y_ref.ndim > 1 else (0,)
-        empty_x = np.array([], dtype=x_ref.dtype).reshape(empty_x_shape)
-        empty_y = np.array([], dtype=y_ref.dtype).reshape(empty_y_shape)
+        empty_x = array([], dtype=x_ref.dtype).reshape(empty_x_shape)
+        empty_y = array([], dtype=y_ref.dtype).reshape(empty_y_shape)
         return empty_x, empty_y

--- a/src/models/base/keras_setup.py
+++ b/src/models/base/keras_setup.py
@@ -3,10 +3,12 @@ _keras_base = None
 try:
     # noinspection PyUnresolvedReferences
     import tensorflow.keras as _keras_base
+
     print("Using Keras from 'tensorflow.keras'")
 except ImportError:
     # noinspection PyUnresolvedReferences
     import keras as _keras_base
+
     print("Using Keras from 'keras.src'")
 
 keras_base = _keras_base

--- a/src/models/prediction/components/data_processor.py
+++ b/src/models/prediction/components/data_processor.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, Optional
 
-import numpy as np
-from numpy import float32, float64
+from numpy import array, expand_dims, float32, float64
 from numpy.typing import NDArray
 from sklearn.preprocessing import MinMaxScaler
 from typing_extensions import override
@@ -213,8 +212,8 @@ class PredictionDataProcessor(
         if len(numerical_sequence) != training_week_len:
             raise ValueError("Failed to create a numerical sequence of the required length.")
 
-        unscaled_array: NDArray[float32] = np.expand_dims(
-            np.array(numerical_sequence, dtype=float32), axis=0
+        unscaled_array: NDArray[float32] = expand_dims(
+            array(numerical_sequence, dtype=float32), axis=0
         )
         scaled_array: NDArray[float32] = self._scale_feature_in_sequences(sequences=unscaled_array)
         return scaled_array
@@ -320,7 +319,7 @@ class PredictionDataProcessor(
                 x_list.append(seq_x)
                 y_list.append(seq_y)
 
-        return np.array(x_list, dtype=float32), np.array(y_list, dtype=float64)
+        return array(x_list, dtype=float32), array(y_list, dtype=float64)
 
     @staticmethod
     def _extract_features_from_week(week: WeekData) -> PredictionFeature:
@@ -395,9 +394,9 @@ class PredictionDataProcessor(
 
         # Initialize and fit the scaler ONLY on the training target data
         self.scaler = MinMaxScaler()
-        y_train_scaled = self.scaler.fit_transform(y_train.reshape(-1, 1)) if len(y_train) > 0 else np.array([])
-        y_val_scaled = self.scaler.transform(y_val.reshape(-1, 1)) if len(y_val) > 0 else np.array([])
-        y_test_scaled = self.scaler.transform(y_test.reshape(-1, 1)) if len(y_test) > 0 else np.array([])
+        y_train_scaled = self.scaler.fit_transform(y_train.reshape(-1, 1)) if len(y_train) > 0 else array([])
+        y_val_scaled = self.scaler.transform(y_val.reshape(-1, 1)) if len(y_val) > 0 else array([])
+        y_test_scaled = self.scaler.transform(y_test.reshape(-1, 1)) if len(y_test) > 0 else array([])
 
         # Scale the box office feature (index 0) in x sets
         x_train_scaled = self._scale_feature_in_sequences(sequences=x_train)

--- a/src/models/prediction/components/data_processor.py
+++ b/src/models/prediction/components/data_processor.py
@@ -409,3 +409,26 @@ class PredictionDataProcessor(
             x_val=x_val_scaled, y_val=y_val_scaled.flatten(),
             x_test=x_test_scaled, y_test=y_test_scaled.flatten()
         )
+
+    @staticmethod
+    def get_range_index(value: float, ranges: tuple[int, ...]) -> int:
+        """
+        Determines the index of the range a given value falls into.
+
+        This method is centralized here as it represents a form of data transformation
+        and is part of the public utility API of this class.
+
+        :param value: The box office value to classify.
+        :param ranges: A tuple of upper boundaries defining the ranges (e.g., (1M, 10M, 90M)).
+        :returns: The integer index of the corresponding range.
+        """
+        # Sort ranges to ensure correct interval checking
+        sorted_ranges: list[int] = sorted(list(ranges))
+
+        # Find the first range boundary that the value is less than
+        for i, boundary in enumerate(sorted_ranges):
+            if value < boundary:
+                return i
+
+        # If the value is greater than or equal to all boundaries, it belongs to the last range
+        return len(sorted_ranges)

--- a/src/models/prediction/components/evaluator.py
+++ b/src/models/prediction/components/evaluator.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import numpy as np
 from numpy.typing import NDArray
-from sklearn.metrics import f1_score
 from sklearn.preprocessing import MinMaxScaler
 from typing_extensions import override
 
@@ -22,6 +21,7 @@ from src.models.prediction.components.model_core import (
     PredictionEvaluateConfig,
     PredictionPredictConfig,
 )
+from src.utilities.metrics import RegressionToClassificationMetrics
 
 History = keras_base.callbacks.History
 
@@ -37,12 +37,14 @@ class PredictionEvaluationConfig(BaseEvaluationConfig):
     :ivar calculate_trend_accuracy: Flag to calculate trend prediction accuracy.
     :ivar calculate_range_accuracy: Flag to calculate range prediction accuracy.
     :ivar box_office_ranges: A tuple defining the upper boundaries of box office ranges.
+    :ivar f1_average_method: The averaging method for F1 score calculation.
     """
 
-    training_week_len: int
-    calculate_trend_accuracy: bool
-    calculate_range_accuracy: bool
+    training_week_len: int = 4
+    calculate_trend_accuracy: bool = False
+    calculate_range_accuracy: bool = False
     box_office_ranges: tuple[int, ...] = (1_000_000, 10_000_000, 90_000_000)
+    f1_average_method: str = 'macro'
 
 
 @dataclass(frozen=True)
@@ -197,14 +199,15 @@ class PredictionEvaluator(
                 metrics['trend_accuracy'] = self._calculate_trend_accuracy(
                     predictions=unscaled_pred, actual=unscaled_actual, last_inputs=unscaled_inputs
                 )
-            if config.calculate_range_accuracy:
-                metrics['test_accuracy'] = self._calculate_range_accuracy(
-                    predictions=unscaled_pred, actual=unscaled_actual, ranges=config.box_office_ranges
+
+            if config.calculate_range_accuracy or config.calculate_f1_score:
+                class_metrics: dict[str, float] = self._calculate_classification_metrics(
+                    predictions=unscaled_pred,
+                    actual=unscaled_actual,
+                    config=config
                 )
-            if config.calculate_f1_score:
-                metrics['f1_score'] = self._calculate_f1_score(
-                    predictions=unscaled_pred, actual=unscaled_actual, config=config
-                )
+                metrics.update(class_metrics)
+
         return metrics
 
     @override
@@ -284,22 +287,48 @@ class PredictionEvaluator(
 
         return unscaled_predictions, unscaled_actual, unscaled_last_week_inputs
 
-    @staticmethod
-    def _get_range_index(value: float, ranges: tuple[int, ...]) -> int:
+    def _calculate_classification_metrics(
+        self,
+        predictions: list[float],
+        actual: list[float],
+        config: PredictionEvaluationConfig
+    ) -> dict[str, float]:
         """
-        Determines the index of the range a given value falls into.
+        Calculates classification-based metrics using the metrics framework.
 
-        :param value: The box office value to classify.
-        :param ranges: A tuple of upper boundaries defining the ranges.
-        :returns: The integer index of the corresponding range.
+        :param predictions: A list of unscaled predicted box office values.
+        :param actual: A list of unscaled actual box office values.
+        :param config: The evaluation configuration.
+        :returns: A dictionary with 'test_accuracy' and 'f1_score'.
         """
-        # This logic is now centralized.
-        thresholds: list[float] = [-float('inf')] + sorted(list(ranges)) + [float('inf')]
-        for i in range(len(thresholds) - 1):
-            if thresholds[i] <= value < thresholds[i + 1]:
-                return i
-        # Handle edge case where value might be exactly the last boundary or infinity
-        return len(thresholds) - 2
+        self.logger.info("Calculating classification-based metrics (Range Accuracy, F1-Score)...")
+
+        # 1. Define the value-to-label function.
+        def value_to_label_fn(value: float) -> int:
+            # Use the centralized method from the data processor
+            return PredictionDataProcessor.get_range_index(value=value, ranges=config.box_office_ranges)
+
+        # 2. Instantiate and configure the metrics calculator.
+        metrics_calculator: RegressionToClassificationMetrics = RegressionToClassificationMetrics(
+            value_to_label_fn=value_to_label_fn,
+            f1_average_method=config.f1_average_method
+        )
+
+        # 3. Generate the report.
+        report: dict[str, any] = metrics_calculator.generate_report(
+            y_true=array(actual),
+            y_pred=array(predictions)
+        )
+
+        # 4. Log and return the results.
+        accuracy: float = report.get('accuracy', 0.0)
+        f1: float = report.get('f1_score', 0.0)
+
+        self.logger.info(f"  - Range Accuracy: {accuracy:.2%}")
+        self.logger.info(f"  - F1-Score (average='{config.f1_average_method}'): {f1:.4f}")
+        self.logger.debug(f"Full classification report:\n{report.get('report_string')}")
+
+        return {'test_accuracy': accuracy, 'f1_score': f1}
 
     def _calculate_trend_accuracy(
         self, predictions: list[float], actual: list[float], last_inputs: list[float]
@@ -315,56 +344,12 @@ class PredictionEvaluator(
         :param last_inputs: A list of unscaled box office values from the last input week.
         :returns: The trend accuracy, a float between 0.0 and 1.0.
         """
-        correct_predictions = 0
-        for pred, actual, last_input in zip(predictions, actual, last_inputs):
-            pred_trend = 1 if pred > last_input else 0
-            actual_trend = 1 if actual > last_input else 0
+        correct_predictions: int = 0
+        for pred, act, last_input in zip(predictions, actual, last_inputs):
+            pred_trend: int = 1 if pred > last_input else 0
+            actual_trend: int = 1 if act > last_input else 0
             if pred_trend == actual_trend:
                 correct_predictions += 1
-        accuracy = correct_predictions / len(predictions) if predictions else 0.0
+        accuracy: float = correct_predictions / len(predictions) if predictions else 0.0
         self.logger.info(f"  - Trend Accuracy: {accuracy:.2%}")
         return accuracy
-
-    def _calculate_range_accuracy(
-        self, predictions: list[float], actual: list[float], ranges: tuple[int, ...]
-    ) -> float:
-        """
-        Calculates the range prediction accuracy.
-
-        This metric measures how often the predicted box office value falls into
-        the same predefined revenue range as the actual value.
-
-        :param predictions: A list of unscaled predicted box office values.
-        :param actual: A list of unscaled actual box office values.
-        :param ranges: A tuple of upper boundaries defining the box office ranges.
-        :returns: The range accuracy, a float between 0.0 and 1.0.
-        """
-        correct_predictions: int = 0
-        for pred, actual in zip(predictions, actual):
-            if self._get_range_index(pred, ranges) == self._get_range_index(actual, ranges):
-                correct_predictions += 1
-        accuracy: float = correct_predictions / len(predictions) if predictions else 0.0
-        self.logger.info(f"  - Range Accuracy: {accuracy:.2%}")
-        return accuracy
-
-    def _calculate_f1_score(
-        self, predictions: list[float], actual: list[float], config: PredictionEvaluationConfig
-    ) -> float:
-        """
-        Calculates the F1-score for the range prediction task.
-
-        This treats the range prediction as a multi-class classification problem
-        and computes the F1-score based on the method specified in the config.
-
-        :param predictions: A list of unscaled predicted box office values.
-        :param actual: A list of unscaled actual box office values.
-        :param config: The evaluation configuration, used to access box office ranges
-                       and the F1 averaging method.
-        :returns: The calculated F1-score.
-        """
-        y_pred_labels: list[int] = [self._get_range_index(p, config.box_office_ranges) for p in predictions]
-        y_true_labels: list[int] = [self._get_range_index(a, config.box_office_ranges) for a in actual]
-
-        score: float = f1_score(y_true_labels, y_pred_labels, average=config.f1_average_method, zero_division=0)
-        self.logger.info(f"  - F1-Score (average='{config.f1_average_method}'): {score:.4f}")
-        return score

--- a/src/models/prediction/components/evaluator.py
+++ b/src/models/prediction/components/evaluator.py
@@ -2,23 +2,24 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-import numpy as np
+from numpy import array, float32, float64
 from numpy.typing import NDArray
 from sklearn.preprocessing import MinMaxScaler
 from typing_extensions import override
 
-from src.core.project_config import ProjectPaths, ProjectModelType
-from src.models.base.base_evaluator import BaseEvaluator, BaseEvaluationResult, BaseEvaluationConfig
+from src.core.project_config import ProjectModelType, ProjectPaths
+from src.data_handling.movie_collections import MovieData
+from src.models.base.base_evaluator import BaseEvaluationConfig, BaseEvaluationResult, BaseEvaluator
 from src.models.base.keras_setup import keras_base
 from src.models.prediction.components.data_processor import (
+    PredictionDataConfig,
     PredictionDataProcessor,
     PredictionDataSource,
-    PredictionDataConfig,
     PredictionTrainingProcessedData,
 )
 from src.models.prediction.components.model_core import (
-    PredictionModelCore,
     PredictionEvaluateConfig,
+    PredictionModelCore,
     PredictionPredictConfig,
 )
 from src.utilities.metrics import RegressionToClassificationMetrics
@@ -69,7 +70,8 @@ class PredictionEvaluator(
 
     This evaluator loads a specific model checkpoint and its corresponding scaler,
     recreates the test dataset, and computes various performance metrics such as
-    MSE loss, trend accuracy, range accuracy, and F1-score.
+    MSE loss, trend accuracy, and delegates classification-based metrics to a
+    centralized framework.
     """
 
     @override
@@ -90,22 +92,22 @@ class PredictionEvaluator(
         :raises FileNotFoundError: If the scaler artifact cannot be found or loaded.
         """
         self.logger.info("Step 1: Loading model and data processor artifacts...")
-        artifacts_path = ProjectPaths.get_model_root_path(
+        artifacts_path: Path = ProjectPaths.get_model_root_path(
             model_id=model_id, model_type=ProjectModelType.PREDICTION
         )
-        model_file_path = artifacts_path / f"{model_id}_{model_epoch:04d}.keras"
+        model_file_path: Path = artifacts_path / f"{model_id}_{model_epoch:04d}.keras"
 
-        data_processor = PredictionDataProcessor(model_artifacts_path=artifacts_path)
+        data_processor: PredictionDataProcessor = PredictionDataProcessor(model_artifacts_path=artifacts_path)
         if not data_processor.scaler:
             raise FileNotFoundError(f"Could not load scaler artifact from: {artifacts_path}")
 
-        model_core = PredictionModelCore(model_path=model_file_path)
+        model_core: PredictionModelCore = PredictionModelCore(model_path=model_file_path)
         return data_processor, model_core, artifacts_path
 
     @override
     def _prepare_test_data(
         self, data_processor: PredictionDataProcessor, config: PredictionEvaluationConfig
-    ) -> tuple[NDArray[np.float32], NDArray[np.float64]]:
+    ) -> tuple[NDArray[float32], NDArray[float64]]:
         """
         Loads and processes data to retrieve the evaluation set.
 
@@ -120,10 +122,10 @@ class PredictionEvaluator(
                             or `random_state` are not provided in the config.
         """
         self.logger.info("Step 3: Loading and processing evaluation dataset...")
-        data_source = PredictionDataSource(dataset_name=config.dataset_name)
-        raw_data = data_processor.load_raw_data(source=data_source)
+        data_source: PredictionDataSource = PredictionDataSource(dataset_name=config.dataset_name)
+        raw_data: list[MovieData] = data_processor.load_raw_data(source=data_source)
 
-        processing_config = PredictionDataConfig(
+        processing_config: PredictionDataConfig = PredictionDataConfig(
             training_week_len=config.training_week_len,
             split_ratios=config.split_ratios,
             random_state=config.random_state
@@ -154,16 +156,16 @@ class PredictionEvaluator(
         self,
         model_core: PredictionModelCore,
         data_processor: PredictionDataProcessor,
-        x_test: NDArray[np.float32],
-        y_test: NDArray[np.float64],
+        x_test: NDArray[float32],
+        y_test: NDArray[float64],
         config: PredictionEvaluationConfig
     ) -> dict[str, Optional[float]]:
         """
         Calculates various performance metrics based on the evaluation configuration.
 
-        This method orchestrates the calculation of different metrics such as
-        MSE loss, trend accuracy, range accuracy, and F1-score. It un-scales
-        predictions and actual values as needed for certain metrics.
+        This method orchestrates the calculation of MSE loss, trend accuracy,
+        and delegates classification-based metrics (range accuracy, F1-score)
+        to the centralized metrics framework.
 
         :param model_core: The trained model core to use for predictions.
         :param data_processor: The data processor containing the fitted scaler.
@@ -180,7 +182,7 @@ class PredictionEvaluator(
         }
 
         if config.calculate_loss:
-            metrics['test_loss'] = self._calculate_mse_loss(model_core, x_test, y_test)
+            metrics['test_loss'] = self._calculate_mse_loss(model_core=model_core, x_test=x_test, y_test=y_test)
 
         needs_unscaling: bool = any([
             config.calculate_trend_accuracy,
@@ -239,7 +241,7 @@ class PredictionEvaluator(
         )
 
     def _calculate_mse_loss(
-        self, model_core: PredictionModelCore, x_test: NDArray[np.float32], y_test: NDArray[np.float64]
+        self, model_core: PredictionModelCore, x_test: NDArray[float32], y_test: NDArray[float64]
     ) -> float:
         """
         Calculates the Mean Squared Error (MSE) loss on the test set.
@@ -250,14 +252,14 @@ class PredictionEvaluator(
         :returns: The MSE loss value.
         """
         self.logger.info("Step 4a: Calculating MSE loss on the test set...")
-        eval_config = PredictionEvaluateConfig(verbose=0)
+        eval_config: PredictionEvaluateConfig = PredictionEvaluateConfig(verbose=0)
         loss: float = model_core.evaluate(x_test=x_test, y_test=y_test, config=eval_config)
         self.logger.info(f"  - Test MSE Loss: {loss:.6f}")
         return loss
 
     def _get_unscaled_predictions(
         self, model_core: PredictionModelCore, scaler: MinMaxScaler,
-        x_test: NDArray[np.float32], y_test: NDArray[np.float64]
+        x_test: NDArray[float32], y_test: NDArray[float64]
     ) -> tuple[list[float], list[float], list[float]]:
         """
         Generates model predictions and inverse-transforms them to their original scale.
@@ -275,15 +277,15 @@ class PredictionEvaluator(
                   - A list of unscaled box office values from the last input week.
         """
         self.logger.info("Step 4b: Generating unscaled predictions for accuracy metrics...")
-        predict_config = PredictionPredictConfig(verbose=0)
-        y_pred_scaled = model_core.predict(data=x_test, config=predict_config)
+        predict_config: PredictionPredictConfig = PredictionPredictConfig(verbose=0)
+        y_pred_scaled: NDArray[any] = model_core.predict(data=x_test, config=predict_config)
 
-        unscaled_predictions = scaler.inverse_transform(y_pred_scaled).flatten().tolist()
-        unscaled_actual = scaler.inverse_transform(y_test.reshape(-1, 1)).flatten().tolist()
+        unscaled_predictions: list[float] = scaler.inverse_transform(y_pred_scaled).flatten().tolist()
+        unscaled_actual: list[float] = scaler.inverse_transform(y_test.reshape(-1, 1)).flatten().tolist()
 
         # Unscale the last box office value from each input sequence
-        last_week_input_scaled = x_test[:, -1, 0].reshape(-1, 1)
-        unscaled_last_week_inputs = scaler.inverse_transform(last_week_input_scaled).flatten().tolist()
+        last_week_input_scaled: NDArray[float32] = x_test[:, -1, 0].reshape(-1, 1)
+        unscaled_last_week_inputs: list[float] = scaler.inverse_transform(last_week_input_scaled).flatten().tolist()
 
         return unscaled_predictions, unscaled_actual, unscaled_last_week_inputs
 

--- a/src/models/prediction/components/model_core.py
+++ b/src/models/prediction/components/model_core.py
@@ -57,6 +57,7 @@ class PredictionEvaluateConfig(BaseEvaluateConfig):
     """
     pass
 
+
 class PredictionModelCore(
     BaseModelCore[PredictionBuildConfig, PredictionTrainConfig, PredictionPredictConfig, PredictionEvaluateConfig]
 ):

--- a/src/models/prediction/pipelines/training_pipeline.py
+++ b/src/models/prediction/pipelines/training_pipeline.py
@@ -2,10 +2,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from numpy.typing import NDArray
 from typing_extensions import override
 
 from src.core.project_config import ProjectPaths, ProjectModelType
 from src.models.base.base_pipeline import BaseTrainingPipeline
+from src.models.base.callbacks import F1ScoreHistory
 from src.models.base.keras_setup import keras_base
 from src.models.prediction.components.data_processor import (
     PredictionDataProcessor, PredictionDataSource, PredictionDataConfig, PredictionTrainingProcessedData
@@ -13,9 +15,11 @@ from src.models.prediction.components.data_processor import (
 from src.models.prediction.components.model_core import (
     PredictionBuildConfig, PredictionModelCore, PredictionTrainConfig
 )
+from src.utilities.metrics import RegressionToClassificationMetrics
 
 History = keras_base.callbacks.History
 ModelCheckpoint = keras_base.callbacks.ModelCheckpoint
+EarlyStopping = keras_base.callbacks.EarlyStopping
 
 
 @dataclass(frozen=True)
@@ -38,6 +42,10 @@ class PredictionPipelineConfig:
     :ivar verbose: The verbosity mode for Keras training output.
     :ivar checkpoint_interval: The interval in epochs at which to save model checkpoints.
                                If None, only the final model is saved.
+    :ivar early_stopping_patience: Number of epochs with no improvement after which training will be stopped.
+                                  If None, early stopping is disabled.
+    :ivar early_stopping_monitor: Metric to be monitored by early stopping (e.g., 'val_loss', 'val_f1_score').
+    :ivar early_stopping_min_delta: Minimum change in the monitored quantity to qualify as an improvement.
     """
     model_id: str
     dataset_name: str
@@ -50,6 +58,11 @@ class PredictionPipelineConfig:
     random_state: int
     verbose: int | str = 1
     checkpoint_interval: int | None = None
+    early_stopping_patience: Optional[int] = None
+    early_stopping_monitor: str = 'val_loss'
+    early_stopping_min_delta: float = 0.001
+    box_office_ranges: Optional[tuple[int, ...]] = None
+    f1_average_method: str = 'macro'
 
 
 class PredictionTrainingPipeline(
@@ -122,21 +135,36 @@ class PredictionTrainingPipeline(
 
         # Model Training
         self.logger.info("Starting model training...")
-        callbacks_to_use: list[keras_base.callbacks.Callback] = []
+        monitoring_callbacks: list[keras_base.callbacks.Callback] = []
+
+        # Setup F1 History callback (if needed)
+        f1_history_callback: Optional[F1ScoreHistory] = self._setup_f1_score_callback(
+            config=config,
+            validation_data=(processed_data['x_val'], processed_data['y_val'])
+        )
+        if f1_history_callback:
+            monitoring_callbacks.append(f1_history_callback)
+
+        # Setup Early Stopping callback
+        early_stopping_callback: Optional[EarlyStopping] = self._setup_early_stopping_callback(config=config)
+        if early_stopping_callback:
+            monitoring_callbacks.append(early_stopping_callback)
+
+        # Setup Checkpoint callback
         checkpoint_callback: Optional[ModelCheckpoint] = self._setup_checkpoint_callback(
             config=config,
             num_train_samples=len(processed_data['x_train']),
             artifacts_folder=artifacts_folder
         )
         if checkpoint_callback:
-            callbacks_to_use.append(checkpoint_callback)
+            monitoring_callbacks.append(checkpoint_callback)
 
         train_config = PredictionTrainConfig(
             epochs=master_config.epochs,
             batch_size=master_config.batch_size,
             validation_data=(processed_data['x_val'], processed_data['y_val']),
             verbose=master_config.verbose,
-            callbacks=callbacks_to_use,
+            callbacks=monitoring_callbacks,
             initial_epoch=continue_from_epoch or 0
         )
         history: History = self.model_core.train(
@@ -150,9 +178,12 @@ class PredictionTrainingPipeline(
             config=master_config,
             history=history,
             artifacts_folder=artifacts_folder,
-            continue_from_epoch=continue_from_epoch
+            callbacks=monitoring_callbacks,
+            continue_from_epoch=continue_from_epoch,
+            f1_history_callback=f1_history_callback
         )
         self.logger.info("--- PREDICTION training pipeline finished successfully. ---")
+
 
     @override
     def _check_required_artifacts_for_continuation(self) -> None:
@@ -169,6 +200,7 @@ class PredictionTrainingPipeline(
                 f"Could not load scaler for continued training from {self.data_processor.model_artifacts_path}."
             )
 
+
     @override
     def _create_model_core(self, model_path: Path) -> PredictionModelCore:
         """
@@ -178,3 +210,50 @@ class PredictionTrainingPipeline(
         :returns: An instance of `PredictionModelCore` with the model loaded.
         """
         return PredictionModelCore(model_path=model_path)
+
+
+    def _setup_f1_score_callback(
+        self,
+        config: PredictionPipelineConfig,
+        validation_data: tuple[NDArray[any], NDArray[any]]
+    ) -> Optional[F1ScoreHistory]:
+        """
+        Sets up the F1ScoreHistory callback if F1 score is being monitored.
+
+        :param config: The master configuration object for this run.
+        :param validation_data: The validation data (x_val, y_val) required by F1ScoreHistory.
+        :returns: The F1ScoreHistory instance if needed, otherwise None.
+        """
+        # If we monitor F1 score, we must add the F1ScoreHistory callback.
+        if 'f1' not in config.early_stopping_monitor:
+            return None
+
+        self.logger.info("F1 score monitoring is enabled. Setting up F1ScoreHistory callback.")
+
+        if not self.data_processor.scaler or config.box_office_ranges is None:
+            self.logger.error(
+                "Cannot set up F1 score monitoring. "
+                "Ensure scaler is loaded and 'box_office_ranges' are configured."
+            )
+            return None
+
+        # Create the function to convert continuous values to labels.
+        scaler = self.data_processor.scaler
+        ranges = config.box_office_ranges
+
+        def value_to_label_fn(value: float) -> int:
+            unscaled_value: float = scaler.inverse_transform([[value]])[0][0]
+            return PredictionDataProcessor.get_range_index(value=unscaled_value, ranges=ranges)
+
+        # Create and configure the metrics calculator.
+        metrics_calculator = RegressionToClassificationMetrics(
+            value_to_label_fn=value_to_label_fn,
+            f1_average_method=config.f1_average_method
+        )
+
+        # Inject the calculator into the F1ScoreHistory callback.
+        f1_history_callback = F1ScoreHistory(
+            validation_data=validation_data,
+            metrics_calculator=metrics_calculator
+        )
+        return f1_history_callback

--- a/src/utilities/evaluation_utils.py
+++ b/src/utilities/evaluation_utils.py
@@ -1,9 +1,0 @@
-from sklearn.metrics import classification_report, accuracy_score
-
-
-def classification_report_to_string(true_labels: list[int], predicted_labels: list[int], target_names=None) -> None:
-    if target_names is None:
-        target_names = ['Negative (0)', 'Positive (1)']
-    accuracy = accuracy_score(true_labels, predicted_labels)
-    print(f"Overall Accuracy: {accuracy:.4f}\n")
-    print(classification_report(true_labels, predicted_labels, target_names=target_names))

--- a/src/utilities/metrics.py
+++ b/src/utilities/metrics.py
@@ -1,0 +1,249 @@
+from abc import ABC, abstractmethod
+from typing import Callable, Optional
+
+from numpy import floating, int_, issubdtype, vectorize
+from numpy.typing import NDArray
+from sklearn.metrics import accuracy_score, classification_report, f1_score
+from typing_extensions import override
+
+
+class BaseClassificationMetrics(ABC):
+    """
+    An abstract base class for calculating and reporting classification metrics.
+
+    This class defines a template method, `generate_report`, which provides a
+    standardized workflow for evaluating classification performance. It relies
+    on subclasses to implement the `_transform_to_labels` method, which
+    converts raw model outputs into discrete class labels suitable for
+    metric calculation.
+
+    :ivar target_names: Optional list of display names for the target classes.
+    :ivar f1_average_method: The averaging method for F1 score calculation
+                             (e.g., 'binary', 'macro', 'weighted').
+    """
+    target_names: Optional[list[str]]
+    f1_average_method: str
+
+    def __init__(
+        self,
+        *,
+        target_names: Optional[list[str]] = None,
+        f1_average_method: str = 'macro'
+    ) -> None:
+        """
+        Initializes the BaseClassificationMetrics.
+
+        :param target_names: Optional display names for the classes in the report.
+        :param f1_average_method: The averaging strategy for the F1 score.
+        """
+        self.target_names: Optional[list[str]] = target_names
+        self.f1_average_method: str = f1_average_method
+
+    @abstractmethod
+    def _transform_to_labels(
+        self,
+        *,
+        y_true: NDArray[any],
+        y_pred: NDArray[any]
+    ) -> tuple[NDArray[int], NDArray[int]]:
+        """
+        Transforms raw true values and predictions into discrete integer labels.
+
+        This is a hook method that must be implemented by all concrete subclasses
+        to provide the specific logic for converting their input data format
+        (e.g., continuous values, probabilities) into class labels.
+
+        :param y_true: The ground-truth values.
+        :param y_pred: The raw predicted values from a model.
+        :return: A tuple containing two NumPy arrays: (true_labels, predicted_labels).
+        """
+        pass
+
+    def generate_report(
+        self,
+        *,
+        y_true: NDArray[any],
+        y_pred: NDArray[any]
+    ) -> dict[str, any]:
+        """
+        Generates a comprehensive classification metrics report.
+
+        This template method orchestrates the evaluation by first transforming
+        the inputs to labels via `_transform_to_labels`, and then computes
+        various metrics like accuracy and a detailed classification report.
+
+        :param y_true: The ground-truth values.
+        :param y_pred: The raw predicted values from a model.
+        :return: A dictionary containing the calculated metrics, including overall
+                 accuracy, F1 score, a structured report dictionary, and a
+                 formatted report string.
+        """
+        # Delegate the transformation step to the concrete subclass.
+        true_labels: NDArray[int_]
+        predicted_labels: NDArray[int_]
+        true_labels, predicted_labels = self._transform_to_labels(y_true=y_true, y_pred=y_pred)
+
+        # Calculate standard classification metrics using the transformed labels.
+        accuracy: float = accuracy_score(y_true=true_labels, y_pred=predicted_labels)
+
+        # Calculate the overall F1 score based on the specified averaging method.
+        overall_f1: float = f1_score(
+            y_true=true_labels, y_pred=predicted_labels, average=self.f1_average_method, zero_division=0
+        )
+
+        # Generate both a dictionary and a string version of the detailed report.
+        report_dict: dict[str, any] = classification_report(
+            y_true=true_labels,
+            y_pred=predicted_labels,
+            target_names=self.target_names,
+            output_dict=True,
+            zero_division=0
+        )
+
+        report_string: str = classification_report(
+            y_true=true_labels,
+            y_pred=predicted_labels,
+            target_names=self.target_names,
+            output_dict=False,
+            zero_division=0
+        )
+
+        # Compile and return all results in a structured dictionary.
+        return {
+            'accuracy': accuracy,
+            'f1_score': overall_f1,
+            'report_dict': report_dict,
+            'report_string': report_string
+        }
+
+
+class BinaryClassificationMetrics(BaseClassificationMetrics):
+    """
+    A concrete metrics calculator for standard binary classification tasks.
+
+    This class assumes that the true values (`y_true`) are already binary labels
+    (0 or 1) and the predicted values (`y_pred`) are probabilities that can be
+    converted to labels using a 0.5 threshold. It can also handle cases where
+    predictions are already provided as integer labels.
+
+    :ivar threshold: The probability threshold to classify a prediction as positive.
+    """
+    threshold: float
+
+    @override
+    def __init__(
+        self,
+        *,
+        target_names: Optional[list[str]] = None,
+        f1_average_method: str = 'binary',
+        threshold: float = 0.5
+    ) -> None:
+        """
+        Initializes the BinaryClassificationMetrics.
+
+        :param target_names: Optional display names for the classes. Defaults to ['Negative', 'Positive'].
+        :param f1_average_method: The averaging strategy, defaulting to 'binary'.
+        :param threshold: The cutoff for classifying probabilities as the positive class.
+        """
+        # If no target names are provided, use a sensible default for binary classification.
+        final_target_names: Optional[list[str]] = target_names if target_names is not None else ['Negative', 'Positive']
+
+        super().__init__(target_names=final_target_names, f1_average_method=f1_average_method)
+        self.threshold: float = threshold
+
+    @override
+    def _transform_to_labels(
+        self,
+        *,
+        y_true: NDArray[any],
+        y_pred: NDArray[any]
+    ) -> tuple[NDArray[int_], NDArray[int_]]:
+        """
+        Overrides the base method to convert probability predictions to binary labels.
+
+        This implementation checks if the predictions are floating-point numbers (probabilities)
+        or integers (pre-classified labels) and processes them accordingly.
+
+        :param y_true: The ground-truth binary labels (0s and 1s).
+        :param y_pred: The predicted values, which can be probabilities (float) or labels (int).
+        :return: A tuple of (true_labels, predicted_labels) as integer arrays.
+        """
+        true_labels: NDArray[int_] = y_true.astype(int_)
+
+        # Check if predictions are probabilities (float) or already labels (int).
+        if issubdtype(y_pred.dtype, floating):
+            # If they are floats, apply the threshold to convert to binary labels.
+            predicted_labels: NDArray[int_] = (y_pred > self.threshold).astype(int_)
+        else:
+            # If they are already integers, use them directly.
+            predicted_labels: NDArray[int_] = y_pred.astype(int_)
+
+        return true_labels, predicted_labels
+
+
+class RegressionToClassificationMetrics(BaseClassificationMetrics):
+    """
+    A concrete metrics calculator for evaluating a regression model on a
+    classification basis.
+
+    This class transforms continuous true values and predictions into discrete
+    class labels using a provided function before calculating classification metrics.
+    It is ideal for tasks like evaluating box office predictions against predefined
+    revenue ranges.
+
+    :ivar value_to_label_fn: The function used to convert a continuous value to a discrete label.
+    """
+    value_to_label_fn: Callable[[float], int]
+
+    @override
+    def __init__(
+        self,
+        *,
+        value_to_label_fn: Callable[[float], int],
+        target_names: Optional[list[str]] = None,
+        f1_average_method: str = 'macro'
+    ) -> None:
+        """
+        Initializes the RegressionToClassificationMetrics.
+
+        :param value_to_label_fn: A function that takes a continuous float value
+                                  and returns a discrete integer label.
+        :param target_names: Optional display names for the classified ranges.
+        :param f1_average_method: The averaging strategy, defaulting to 'macro' for multi-class.
+        """
+        super().__init__(target_names=target_names, f1_average_method=f1_average_method)
+        self.value_to_label_fn: Callable[[float], int] = value_to_label_fn
+
+    @override
+    def _transform_to_labels(
+        self,
+        *,
+        y_true: NDArray[any],
+        y_pred: NDArray[any]
+    ) -> tuple[NDArray[int_], NDArray[int_]]:
+        """
+        Overrides the base method to convert continuous regression values to class labels.
+
+        It applies the `value_to_label_fn` to each element in both the true
+        and predicted value arrays.
+
+        :param y_true: The ground-truth continuous values.
+        :param y_pred: The predicted continuous values from the model.
+        :return: A tuple of (true_labels, predicted_labels) as integer arrays.
+        """
+        # Vectorize the provided Python function so it can be applied to NumPy arrays efficiently.
+        vectorized_transform: Callable[[NDArray[any]], NDArray[int_]] = vectorize(self.value_to_label_fn)
+
+        # Apply the vectorized function to both true and predicted values.
+        true_labels: NDArray[int_] = vectorized_transform(y_true)
+        predicted_labels: NDArray[int_] = vectorized_transform(y_pred)
+
+        return true_labels, predicted_labels
+
+
+def classification_report_to_string(true_labels: list[int], predicted_labels: list[int], target_names=None) -> None:
+    if target_names is None:
+        target_names = ['Negative (0)', 'Positive (1)']
+    accuracy = accuracy_score(true_labels, predicted_labels)
+    print(f"Overall Accuracy: {accuracy:.4f}\n")
+    print(classification_report(true_labels, predicted_labels, target_names=target_names))


### PR DESCRIPTION
Closes #34

#### 1. Problem

Currently, the model training process runs for the full number of `epochs` specified in the configuration. This approach has two main drawbacks:
*   **Inefficiency**: If the model converges early, the training continues unnecessarily, wasting computational resources and time.
*   **Overfitting**: Training for too long can lead to the model overfitting the training data, resulting in poor generalization on the validation and test sets.

To address this, this PR introduces an Early Stopping mechanism. It monitors a specified metric (e.g., `val_loss`) and automatically stops the training when the metric ceases to improve.

---

#### 2. Solution

This change integrates the Early Stopping feature seamlessly across the configuration, CLI, and core training pipeline.

*   **Configuration & CLI (`configs/prediction_defaults.yaml`, `src/cli/argument_parser_builder.py`)**
    *   Added `early_stopping_patience`, `early_stopping_monitor`, and `early_stopping_min_delta` parameters to the default configuration file.
    *   Exposed these settings as command-line arguments to allow for easy overrides during `train` commands.

*   **Generic Callback Setup (`src/models/base/base_pipeline.py`)**
    *   Created a new helper method, `_setup_early_stopping_callback`, within the `BaseTrainingPipeline` class.
    *   This method centralizes the logic for creating a `keras.callbacks.EarlyStopping` instance and critically sets `restore_best_weights=True` to ensure the model automatically reverts to its best state.

*   **Pipeline Integration (`src/models/prediction/pipelines/training_pipeline.py`)**
    *   The `PredictionTrainingPipeline` now calls the new base helper method to create and add the Early Stopping callback to the Keras training process.
    *   The logic for setting up the `F1ScoreHistory` callback was also updated to work in tandem when `val_f1_score` is being monitored.

*   **Intelligent Artifact Saving (`src/models/base/base_pipeline.py`)**
    *   The `_save_run_artifacts` method has been significantly enhanced to **automatically detect** if Early Stopping was triggered.
    *   If triggered, it uses the `best_epoch` attribute from the callback to name the final saved model (e.g., `model_0050.keras`). This ensures the filename **accurately reflects** the best-performing epoch, not the epoch where training stopped.

---

#### 3. Impact/Comparison

*   **Before**:
    *   The model always trained for the full number of epochs defined in the config.
    *   The final saved model corresponded to the **last epoch**, which could be suboptimal or overfitted.

*   **After**:
    *   Training stops automatically when the validation metric ceases to improve, increasing efficiency.
    *   Because `restore_best_weights=True` is used, the final saved model is from the **best-performing epoch**, which improves model generalization and reduces the risk of overfitting.
