### PR TITLE
feat(browser): Add configurable headless mode

### DIFF
--- a/src/data_collection/box_office_collector.py
+++ b/src/data_collection/box_office_collector.py
@@ -244,7 +244,8 @@ class BoxOfficeCollector:
 
     def __init__(self,
                  download_mode: Literal['WEEK', 'WEEKEND'] = 'WEEK',
-                 page_loading_timeout: float = 30) -> None:
+                 page_loading_timeout: float = 30,
+                 headless:bool = False) -> None:
         """
         Initializes the BoxOfficeCollector.
 
@@ -252,12 +253,15 @@ class BoxOfficeCollector:
                               weekly totals, 'WEEKEND' for weekend totals).
         :param page_loading_timeout: The maximum time in seconds to wait for web
                                      pages to load.
+        :param headless: If ``True`` (default), runs the underlying browser in
+                         headless mode. Set to ``False`` to run with a visible GUI.
         """
         self.__logger: Logger = LoggingManager().get_logger('root')
         self.__download_mode: Final[Literal['WEEK', 'WEEKEND']] = download_mode
         self.__logger.info(f"Using {self.__download_mode} mode to download data.")
         self.__scrap_file_extension: Final[str] = 'json'
         self.__page_loading_timeout: Final[float] = page_loading_timeout
+        self.__headless:Final[bool] = headless
 
         self.__browser: Optional[Browser] = None
         return
@@ -272,6 +276,7 @@ class BoxOfficeCollector:
         """
         self.__logger.debug("Entering context, initializing browser...")
         self.__browser = Browser(
+            headless=self.__headless,
             download_path=Path(tempfile.gettempdir()),
             page_loading_timeout=self.__page_loading_timeout
         )

--- a/src/data_collection/browser.py
+++ b/src/data_collection/browser.py
@@ -110,7 +110,10 @@ class Browser(webdriver.Chrome):
         error_message: str
 
     @override
-    def __init__(self, download_path: Optional[Path] = None, page_loading_timeout: float = 120,
+    def __init__(self,
+                 headless:bool = True,
+                 download_path: Optional[Path] = None,
+                 page_loading_timeout: float = 120,
                  target_url: Optional[str] = None) -> None:
         """
         Initializes the Browser.
@@ -133,7 +136,8 @@ class Browser(webdriver.Chrome):
 
         # options
         self.__options: Options = Options()
-        self.__options.add_argument(argument="--headless")
+        if headless:
+            self.__options.add_argument(argument="--headless")
         self.__options.add_argument(argument="--no-sandbox")
         self.__options.add_argument(argument="--disable-dev-shm-usage")
         self.__options.add_argument(argument="--disable-gpu")


### PR DESCRIPTION
This PR introduces a configurable headless mode for the `Browser` class to enhance its flexibility when dealing with websites that have anti-scraping mechanisms. The previous implementation hardcoded the `--headless` argument, which caused interaction failures on certain sites.

### Problem Addressed

- **Hardcoded Headless Mode**: The `Browser` class always ran in headless mode, which is detectable by some websites (e.g., PTT search).
- **Interaction Failures**: This detection led to failures in browser automation, such as `click()` events not working, causing scripts to hang or fail.
- **Lack of Flexibility**: The collector classes had no way to disable headless mode when targeting these specific websites.

### Changes Implemented

- **`Browser` Class Refactoring**:
  - A new `headless: bool = True` parameter has been added to the `Browser.__init__` method.
  - The `--headless` argument is now conditionally applied only when `headless` is `True`.

- **`BoxOfficeCollector` Update**:
  - The `headless` parameter has been propagated up to the `BoxOfficeCollector.__init__` method.
  - The default value for `headless` in `BoxOfficeCollector` is set to `False`, as its target website is known to require a visible GUI for reliable operation.

### Impact

This enhancement makes the `Browser` class a more versatile tool, capable of being adapted for different scraping targets without internal modification. It unblocks the development of collectors for websites that require a non-headless environment while preserving the efficiency of headless mode for other tasks.

Closes #39
