### PR TITLE
refactor(core): Enhance config type safety and clean up PredictionDataConfig

### DIFF
--- a/src/cli/handlers/base_model_handler.py
+++ b/src/cli/handlers/base_model_handler.py
@@ -3,14 +3,17 @@ from argparse import ArgumentParser, Namespace
 from logging import Formatter, Handler, Logger, StreamHandler
 from pathlib import Path
 from random import randint
+from typing import cast, Generic, TypeVar
 
 from src.core.logging_manager import HandlerSettings, LoggingManager, LogLevel
 from src.core.project_config import ProjectModelType, ProjectPaths
 from src.data_handling.file_io import PickleFile, YamlFile
 from src.models.base.evaluation import BaseEvaluationConfig, BaseEvaluationResult, BaseEvaluator
 
+ConfigDictType = TypeVar('ConfigDictType', bound=dict)
 
-class BaseModelHandler(ABC):
+
+class BaseModelHandler(Generic[ConfigDictType], ABC):
     """
     An abstract base class for model handlers to reduce code duplication.
 
@@ -85,10 +88,10 @@ class BaseModelHandler(ABC):
             'training_loss', 'validation_loss', 'test_loss',
             'classification_report', 'show_f1_score', 'show_confusion_matrix'
         ]
-        original_config_data: dict[str, any] = self._prepare_evaluation_context(args=args, required_flags=metric_flags)
+        original_config_data: ConfigDictType = self._prepare_evaluation_context(args=args, required_flags=metric_flags)
 
         try:
-            eval_config: any = self._build_evaluation_config(
+            eval_config: BaseEvaluationConfig = self._build_evaluation_config(
                 args=args,
                 original_config_data=original_config_data,
                 epoch_to_evaluate=args.epoch
@@ -129,7 +132,7 @@ class BaseModelHandler(ABC):
         """
         pass
 
-    def _prepare_training_config(self, args: Namespace) -> dict[str, any]:
+    def _prepare_training_config(self, args: Namespace) -> ConfigDictType:
         """
         A template method to prepare the final configuration for a training run.
 
@@ -170,7 +173,7 @@ class BaseModelHandler(ABC):
             if args.config_override:
                 self._parser.error("Argument --config-override cannot be used with --continue-from-epoch.")
 
-            individual_overrides: dict[str, any] = self._get_individual_overrides(args=args, is_continue_mode=True)
+            individual_overrides: ConfigDictType = self._get_individual_overrides(args=args, is_continue_mode=True)
             if individual_overrides:
                 self._parser.error(
                     f"Individual overrides like --{next(iter(individual_overrides))} cannot be used with --continue-from-epoch.")
@@ -182,29 +185,35 @@ class BaseModelHandler(ABC):
                 )
 
             self._logger.info(f"Using existing configuration file: {final_config_path}")
-            return YamlFile(path=final_config_path).load_single_document()
+            loaded_config: ConfigDictType = cast(
+                ConfigDictType, YamlFile(path=final_config_path).load_single_document()
+            )
+            return loaded_config
 
         else:
             # Mode: New Training
             self._logger.info(f"Executing: Start new training for {self._model_type_name} model '{model_id}'.")
 
             # Check for mutually exclusive arguments
-            individual_overrides: dict[str, any] = self._get_individual_overrides(args=args, is_continue_mode=False)
+            individual_overrides: ConfigDictType = self._get_individual_overrides(args=args, is_continue_mode=False)
             if args.config_override and individual_overrides:
                 self._parser.error("Argument --config-override cannot be used with individual parameter overrides.")
 
             # Load default configuration using the abstract method
             default_config_filename: str = self._get_default_config_filename()
             default_config_path: Path = ProjectPaths.get_config_path(config_name=default_config_filename)
+
             try:
-                default_config: dict[str, any] = YamlFile(path=default_config_path).load_single_document()
+                loaded_default_data: dict[str, any] = YamlFile(path=default_config_path).load_single_document()
+                default_config: ConfigDictType = loaded_default_data
                 self._logger.info(f"Loaded default configuration from: {default_config_path}")
             except FileNotFoundError:
                 self._parser.error(
                     f"Default configuration file '{default_config_filename}' not found at: {default_config_path}")
 
             # Apply overrides
-            effective_config: dict[str, any] = default_config.copy()
+            # noinspection PyTypeChecker
+            effective_config: ConfigDictType = default_config.copy()
             if args.config_override:
                 try:
                     self._logger.info(f"Applying overrides from file: {args.config_override}")
@@ -237,7 +246,7 @@ class BaseModelHandler(ABC):
             except Exception as e:
                 self._parser.error(f"Failed to save final configuration file: {e}")
 
-            return effective_config
+            return cast(ConfigDictType, effective_config)
 
     @abstractmethod
     def _get_evaluation_cache_filename(self) -> str:
@@ -253,7 +262,7 @@ class BaseModelHandler(ABC):
 
     @abstractmethod
     def _build_evaluation_config(
-        self, args: Namespace, original_config_data: dict[str, any], epoch_to_evaluate: int
+        self, args: Namespace, original_config_data: ConfigDictType, epoch_to_evaluate: int
     ) -> BaseEvaluationConfig:
         """
         Builds the appropriate evaluation configuration object for a single epoch.
@@ -298,7 +307,7 @@ class BaseModelHandler(ABC):
             'training_loss', 'validation_loss', 'test_loss',
             'classification_report', 'show_f1_score', 'show_confusion_matrix'
         ]
-        original_config_data: dict[str, any] = self._prepare_evaluation_context(args=args, required_flags=metric_flags)
+        original_config_data: ConfigDictType = self._prepare_evaluation_context(args=args, required_flags=metric_flags)
 
         artifacts_folder: Path = ProjectPaths.get_model_root_path(model_id=model_id, model_type=self._model_type)
         available_epochs: list[int] = self._find_available_epochs(model_id=model_id, model_type=self._model_type)
@@ -389,16 +398,18 @@ class BaseModelHandler(ABC):
         return sorted(epochs)
 
     @staticmethod
-    def _get_individual_overrides(args: Namespace, is_continue_mode: bool = False) -> dict[str, any]:
+    def _get_individual_overrides(args: Namespace, is_continue_mode: bool = False) -> ConfigDictType:
         """
         Extracts individual parameter overrides from the argparse Namespace.
 
         This helper method filters out arguments that are not considered
-        overridable parameters.
+        overridable parameters and casts the result to the generic ConfigDictType.
+        This explicitly indicates that the returned dictionary represents a
+        partial configuration.
 
         :param args: The namespace object from argparse.
         :param is_continue_mode: A flag to adjust the keys to exclude for continuation mode.
-        :returns: A dictionary of individual override parameters.
+        :returns: A dictionary of individual override parameters, typed as ConfigDictType.
         """
         # Keys that are part of the CLI mechanism, not overridable config values
         # The subcommand key can vary, so find it dynamically.
@@ -411,12 +422,12 @@ class BaseModelHandler(ABC):
         if is_continue_mode:
             base_exclude_keys.add('continue_from_epoch')
 
-        return {
+        return cast(ConfigDictType, {
             key: value for key, value in vars(args).items()
             if key not in base_exclude_keys and value is not None
-        }
+        })
 
-    def _prepare_evaluation_context(self, args: Namespace, required_flags: list[str]) -> dict[str, any]:
+    def _prepare_evaluation_context(self, args: Namespace, required_flags: list[str]) -> ConfigDictType:
         """
         Performs common setup tasks for evaluation commands.
 
@@ -450,7 +461,7 @@ class BaseModelHandler(ABC):
             self._parser.error(f"Master config file 'config.yaml' not found for model_id '{args.model_id}'.")
 
         try:
-            return YamlFile(path=config_path).load_single_document()
+            return cast(ConfigDictType, YamlFile(path=config_path).load_single_document())
         except Exception as e:
             self._parser.error(f"Failed to load or parse config file at '{config_path}': {e}")
 

--- a/src/cli/handlers/gradient_model_handler.py
+++ b/src/cli/handlers/gradient_model_handler.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from typing_extensions import override
 
-from src.cli.handlers.base_model_handler import BaseModelHandler
+from src.cli.handlers.base_model_handler import BaseModelHandler, ConfigDictType
 from src.core.project_config import ProjectPaths
 from src.models.base.evaluation import (
     BaseEvaluationResult,
@@ -16,7 +16,7 @@ from src.models.base.evaluation import (
 from src.utilities.plot import PlotDataset, plot_multi_line_graph
 
 
-class GradientModelHandler(BaseModelHandler, ABC):
+class GradientModelHandler(BaseModelHandler[ConfigDictType], ABC):
     """
     An abstract handler for models trained with gradient descent.
 
@@ -27,10 +27,10 @@ class GradientModelHandler(BaseModelHandler, ABC):
 
     @abstractmethod
     def _plot_specific_graphs(
-            self,
-            eval_results: list[BaseEvaluationResult],
-            output_dir: Path,
-            args: Namespace
+        self,
+        eval_results: list[BaseEvaluationResult],
+        output_dir: Path,
+        args: Namespace
     ) -> None:
         """
         Plots graphs for metrics specific to the concrete model type.
@@ -80,7 +80,7 @@ class GradientModelHandler(BaseModelHandler, ABC):
         self._plot_specific_graphs(eval_results=eval_results, output_dir=output_dir, args=args)
 
     def _plot_loss_graph(
-            self, eval_results: list[BaseEvaluationResult], output_dir: Path, args: Namespace
+        self, eval_results: list[BaseEvaluationResult], output_dir: Path, args: Namespace
     ) -> None:
         """
         Plots the common loss curves for a model (Training and Validation).
@@ -125,7 +125,7 @@ class GradientModelHandler(BaseModelHandler, ABC):
         )
 
 
-class RegressionModelHandler(GradientModelHandler, ABC):
+class RegressionModelHandler(GradientModelHandler[ConfigDictType], ABC):
     """
     An abstract handler for regression models trained with gradient descent.
 
@@ -136,10 +136,10 @@ class RegressionModelHandler(GradientModelHandler, ABC):
 
     @override
     def _plot_specific_graphs(
-            self,
-            eval_results: list[BaseEvaluationResult],
-            output_dir: Path,
-            args: Namespace
+        self,
+        eval_results: list[BaseEvaluationResult],
+        output_dir: Path,
+        args: Namespace
     ) -> None:
         """
         Plots graphs specific to regression models, primarily the test loss curve.
@@ -198,7 +198,7 @@ class RegressionModelHandler(GradientModelHandler, ABC):
             result_logger.info(f"  - Test Loss (MSE): {result.regression_report['mse']:.6f}")
 
 
-class ClassificationModelHandler(GradientModelHandler, ABC):
+class ClassificationModelHandler(GradientModelHandler[ConfigDictType], ABC):
     """
     An abstract handler for classification models trained with gradient descent.
 
@@ -209,10 +209,10 @@ class ClassificationModelHandler(GradientModelHandler, ABC):
 
     @override
     def _plot_specific_graphs(
-            self,
-            eval_results: list[BaseEvaluationResult],
-            output_dir: Path,
-            args: Namespace
+        self,
+        eval_results: list[BaseEvaluationResult],
+        output_dir: Path,
+        args: Namespace
     ) -> None:
         """
         Plots graphs specific to classification models, such as the F1-score curve.

--- a/src/cli/handlers/prediction_model_handler.py
+++ b/src/cli/handlers/prediction_model_handler.py
@@ -16,7 +16,11 @@ from src.data_handling.file_io import YamlFile
 from src.data_handling.movie_collections import MovieData
 from src.data_handling.movie_metadata import MovieMetadata
 from src.models.base.evaluation import BaseEvaluationResult
-from src.models.prediction.components.data_processor import PredictionDataConfig, PredictionDataProcessor
+from src.models.prediction.components.data_processor import (
+    PredictionConfigDict,
+    PredictionDataConfig,
+    PredictionDataProcessor
+)
 from src.models.prediction.components.evaluator import (
     PredictionEvaluationConfig,
     PredictionEvaluationResult,
@@ -27,7 +31,7 @@ from src.models.prediction.pipelines.training_pipeline import PredictionPipeline
 from src.utilities.plot import plot_multi_line_graph
 
 
-class PredictionModelHandler(RegressionModelHandler):
+class PredictionModelHandler(RegressionModelHandler[PredictionConfigDict]):
     """
     Handles CLI commands related to the box office prediction model.
 
@@ -65,7 +69,7 @@ class PredictionModelHandler(RegressionModelHandler):
                      other training-related parameters.
         :raises SystemExit: If there is a configuration error or the pipeline fails.
         """
-        effective_config: dict[str, any] = self._prepare_training_config(args=args)
+        effective_config: PredictionConfigDict = self._prepare_training_config(args=args)
 
         try:
             artifacts_folder: Path = ProjectPaths.get_model_root_path(
@@ -303,7 +307,7 @@ class PredictionModelHandler(RegressionModelHandler):
 
     @override
     def _build_evaluation_config(
-        self, args: Namespace, original_config_data: dict[str, any], epoch_to_evaluate: int
+        self, args: Namespace, original_config_data:PredictionConfigDict, epoch_to_evaluate: int
     ) -> PredictionEvaluationConfig:
         """
         Builds the evaluation configuration object for a single epoch.

--- a/src/models/base/base_data_processor.py
+++ b/src/models/base/base_data_processor.py
@@ -1,22 +1,49 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Generic, Optional, TypeVar
 
+from src.utilities.decorators import frozen_after_init
 
-@dataclass(frozen=True)
+
+@frozen_after_init
 class BaseDataConfig:
     """
-    A base dataclass for data processing configurations.
+    The base class for all data processing configurations.
 
-    Defines common attributes required for processing data for model training,
-    such as data splitting parameters.
+    Implements a manual 'frozen' mechanism to ensure immutability after initialization.
 
-    :ivar split_ratios: The ratio for splitting data into train, validation, and test sets.
-    :ivar random_state: The seed used by the random number generator for data splitting.
+    :ivar _locked: Internal flag to indicate if the instance is locked.
     """
-    split_ratios: tuple[int, int, int]
-    random_state: int
+    _locked: bool = False
+
+    def __init__(self, **kwargs: any):
+        """
+        Initializes the BaseDataConfig instance.
+
+        Allows subclasses to pass unused keyword arguments up the chain.
+
+        :param kwargs: Arbitrary keyword arguments.
+        """
+        pass
+
+    def __setattr__(self, name: str, value: any) -> None:
+        """
+        Sets an attribute on the instance, enforcing immutability if locked.
+
+        :param name: The name of the attribute.
+        :param value: The value to assign.
+        :raises AttributeError: If the instance is locked.
+        """
+        if self._locked:
+            raise AttributeError(f"Cannot assign to attribute '{name}'. Instance is immutable.")
+
+        super().__setattr__(name, value)
+
+    def _lock(self) -> None:
+        """
+        Locks the instance, making it immutable.
+        """
+        object.__setattr__(self, '_locked', True)
 
 
 RawDataSourceType = TypeVar('RawDataSourceType')

--- a/src/models/base/gradient_data_processor.py
+++ b/src/models/base/gradient_data_processor.py
@@ -1,7 +1,8 @@
 from abc import abstractmethod
+from dataclasses import dataclass
 from logging import Logger
 from pathlib import Path
-from typing import Generic, Optional
+from typing import Generic, Optional, TypeVar
 
 from numpy.typing import NDArray
 from typing_extensions import override
@@ -14,19 +15,83 @@ from src.models.base.base_data_processor import (
     ProcessedTrainingDataType,
     PredictionDataType,
     ProcessedPredictionDataType,
-    DataConfigType
+    DataConfigType, BaseDataConfig
 )
 from src.models.base.data_splitter import DatasetSplitter, SplitDataset, X_Type, Y_Type
 
 
-class EvaluableDataProcessor(
+@dataclass(frozen=True, kw_only=True)
+class SplittingConfig:
+    """
+    A mixin dataclass for configurations that involve data splitting.
+
+    Provides common attributes for splitting data into train, validation, and test sets.
+    These fields are optional as not all modes (e.g., prediction) require them.
+
+    :ivar split_ratios: The ratio for splitting data.
+    :ivar random_state: The seed for the random number generator.
+    """
+    split_ratios: tuple[int, int, int]
+    random_state: int
+
+
+class GradientDataConfig(BaseDataConfig):
+    """
+    Configuration for gradient-based training processes.
+
+    It composes a SplittingConfig object internally.
+
+    :ivar _splitting: The internal splitting configuration.
+    """
+    _splitting: Optional[SplittingConfig]
+
+    def __init__(self, *,
+                 split_ratios: Optional[tuple[int, int, int]] = None,
+                 random_state: Optional[int] = None,
+                 **kwargs: any):
+        """
+        Initializes the GradientDataConfig.
+
+        :param split_ratios: The ratio for splitting data (train, val, test).
+        :param random_state: The seed for the random number generator.
+        :param kwargs: Additional keyword arguments passed to the base class.
+        :raises ValueError: If only one of ``split_ratios`` or ``random_state`` is provided.
+        """
+        super().__init__(**kwargs)
+        if split_ratios is not None and random_state is not None:
+            self._splitting = SplittingConfig(
+                split_ratios=split_ratios,
+                random_state=random_state
+            )
+        elif split_ratios is not None or random_state is not None:
+            raise ValueError("Both 'split_ratios' and 'random_state' must be provided together.")
+        else:
+            self._splitting = None
+
+    @property
+    def split_ratios(self) -> Optional[tuple[int, int, int]]:
+        return self._splitting.split_ratios if self._splitting is not None else None
+
+    @property
+    def random_state(self) -> Optional[int]:
+        return self._splitting.random_state if self._splitting is not None else None
+
+    @property
+    def splittable(self) -> bool:
+        return True if self._splitting is not None else False
+
+
+GradientDataConfigType = TypeVar('GradientDataConfigType', bound=GradientDataConfig)
+
+
+class GradientDataProcessor(
     BaseDataProcessor[
         RawDataSourceType,
         RawDataType,
         ProcessedTrainingDataType,
         PredictionDataType,
         ProcessedPredictionDataType,
-        DataConfigType
+        GradientDataConfigType
     ],
     Generic[
         RawDataSourceType,
@@ -34,7 +99,7 @@ class EvaluableDataProcessor(
         ProcessedTrainingDataType,
         PredictionDataType,
         ProcessedPredictionDataType,
-        DataConfigType,
+        GradientDataConfigType,
         X_Type,
         Y_Type
     ]
@@ -100,7 +165,7 @@ class EvaluableDataProcessor(
         pass
 
     @override
-    def process_for_training(self, raw_data: RawDataType, config: DataConfigType) -> ProcessedTrainingDataType:
+    def process_for_training(self, raw_data: RawDataType, config: GradientDataConfigType) -> ProcessedTrainingDataType:
         """
         A template method that processes raw data for model training.
 
@@ -113,16 +178,22 @@ class EvaluableDataProcessor(
         :param config: A configuration object containing parameters for the training process,
                        such as split ratios and random state.
         :returns: The processed data, ready to be fed into a model.
-        :raises ValueError: If the sum of `split_ratios` in the config is zero.
+        :raises ValueError: If `split_ratios` in the config is not provided.
         """
         self.logger.info("--- Starting data processing for training ---")
 
+        if config.split_ratios is None:
+            raise ValueError(
+                "The 'split_ratios' parameter must be provided in the configuration for the training process."
+            )
+
         # Delegate pre-split processing to subclass
-        self.logger.info("Step 1: Preparing data for splitting...")
+        self.logger.info("Preparing data for splitting...")
         x_to_split, y_to_split = self._prepare_for_split(raw_data=raw_data, config=config)
 
         # Perform the split (common logic)
-        self.logger.info("Step 2: Splitting data into train, validation, and test sets...")
+        self.logger.info("Splitting data into train, validation, and test sets...")
+        # noinspection PyTypeChecker
         split_data: SplitDataset[X_Type, Y_Type] = self.splitter.split(
             x_data=x_to_split,
             y_data=y_to_split,
@@ -132,18 +203,18 @@ class EvaluableDataProcessor(
         )
 
         # Delegate post-split processing to subclass
-        self.logger.info("Step 3: Performing post-split processing (scaling/tokenizing)...")
+        self.logger.info("Performing post-split processing (scaling/tokenizing)...")
         processed_data: ProcessedTrainingDataType = self._post_process_splits(split_data=split_data, config=config)
 
-        self.logger.info("--- Data processing for training finished ---")
+        self.logger.info("Data processing for training finished")
         return processed_data
 
+    # noinspection PyTypeHints
     @abstractmethod
-    def process_for_evaluation(self, raw_data: RawDataType, config: Optional[DataConfigType]) \
+    def process_for_evaluation(self, raw_data: RawDataType, config: Optional[GradientDataConfigType]) \
         -> tuple[NDArray[any], NDArray[any]]:
         """
         Processes a full raw dataset for evaluation without splitting it.
-
 
         :param raw_data: The raw data to be processed for evaluation.
         :param config: An optional configuration object containing necessary parameters.

--- a/src/models/prediction/components/data_processor.py
+++ b/src/models/prediction/components/data_processor.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Optional
+from typing import Final, Optional, TypedDict
 
 from numpy import array, expand_dims, float32, float64
 from numpy.typing import NDArray
@@ -10,10 +10,35 @@ from typing_extensions import override
 from src.data_handling.box_office import BoxOffice
 from src.data_handling.dataset import Dataset
 from src.data_handling.file_io import PickleFile
-from src.data_handling.movie_collections import MovieData, WeekData, MovieSessionData
-from src.models.base.base_data_processor import BaseDataConfig
+from src.data_handling.movie_collections import MovieData, MovieSessionData, WeekData
 from src.models.base.data_splitter import SplitDataset
-from src.models.base.evaluable_data_processor import EvaluableDataProcessor
+from src.models.base.gradient_data_processor import GradientDataProcessor, GradientDataConfig
+
+
+class PredictionConfigDict(TypedDict, total=False):
+    """
+    Type definition for the prediction model's configuration dictionary (loaded from YAML).
+
+    This ensures type safety when handling the raw configuration dictionary before it is converted into specific dataclasses. It includes Optional fields to allow for partial configurations or fields that are not required in all modes (e.g., inference).
+    """
+    model_id: str
+    dataset_name: str
+    training_week_len: int
+    # Made Optional to align with PredictionDataConfig's flexibility for inference mode
+    split_ratios: Optional[tuple[int, int, int]]
+    lstm_units: int
+    dropout_rate: float
+    epochs: int
+    batch_size: int
+    verbose: int
+    checkpoint_interval: int
+    early_stopping_patience: int
+    early_stopping_monitor: str
+    early_stopping_min_delta: float
+    box_office_ranges: list[int]
+    f1_average_method: str
+    # Made Optional as it might not be present in partial configs or inference
+    random_state: Optional[int]
 
 
 @dataclass(frozen=True)
@@ -32,17 +57,36 @@ PredictionPredictionRawData: type = MovieData
 PredictionPredictionProcessedData: type = NDArray[float32]
 
 
-@dataclass(frozen=True)
-class PredictionDataConfig(BaseDataConfig):  # <-- Inherit from BaseDataConfig
+class PredictionDataConfig(GradientDataConfig):
     """
-    Configuration for processing data for prediction model training.
+    Configuration for the prediction model's data processing.
 
-    Inherits common splitting parameters from BaseDataConfig.
+    Inherits splitting capabilities from GradientDataConfig and adds prediction-specific parameters.
 
-    :ivar training_week_len: The number of past weeks to use as input for prediction.
+    :ivar _training_week_len: The length of the training week window.
     """
-    # The common fields are now inherited. We only need to define the unique ones.
-    training_week_len: int
+    _training_week_len: int
+
+    def __init__(self, *,
+                 training_week_len: int,
+                 split_ratios: Optional[tuple[int, int, int]] = None,
+                 random_state: Optional[int] = None,
+                 **kwargs: any):
+        """
+        Initializes the PredictionDataConfig.
+
+        :param training_week_len: The number of weeks of data to use for training.
+        :param split_ratios: The ratio for splitting data (train, val, test).
+        :param random_state: The seed for the random number generator.
+        :param kwargs: Additional keyword arguments passed to the base class.
+        """
+        super().__init__(split_ratios=split_ratios, random_state=random_state, **kwargs)
+
+        self._training_week_len = training_week_len
+
+    @property
+    def training_week_len(self) -> int:
+        return self._training_week_len
 
 
 @dataclass(frozen=True)
@@ -66,7 +110,7 @@ class PredictionFeature:
         """
         Converts the structured features into a numerical list for model input.
 
-        :returns: A list of numerical features in a specific order.
+        :return: A list of numerical features in a specific order.
         """
         return [
             self.box_office,
@@ -78,7 +122,7 @@ class PredictionFeature:
 
 
 class PredictionDataProcessor(
-    EvaluableDataProcessor[
+    GradientDataProcessor[
         PredictionDataSource,
         PredictionTrainingRawData,
         PredictionTrainingProcessedData,
@@ -130,7 +174,6 @@ class PredictionDataProcessor(
         self.model_artifacts_path.mkdir(parents=True, exist_ok=True)
         artifact_path: Path = self.model_artifacts_path / self.SCALER_FILE_NAME
         self.logger.info(f"Saving scaler and settings artifact to: {artifact_path}")
-
         PickleFile(path=artifact_path).save(data=self.scaler)
 
     @override
@@ -163,7 +206,7 @@ class PredictionDataProcessor(
         :returns: A list of MovieData objects.
         """
         self.logger.info(f"Loading raw prediction data from dataset: '{source.dataset_name}'")
-        dataset = Dataset(name=source.dataset_name)
+        dataset: Dataset = Dataset(name=source.dataset_name)
         movie_data_list: list[MovieData] = dataset.load_movie_data(mode='ALL')
 
         if not movie_data_list:
@@ -172,8 +215,9 @@ class PredictionDataProcessor(
         return movie_data_list
 
     @override
-    def process_for_prediction(self, single_input: PredictionPredictionRawData,
-                               config: Optional[PredictionDataConfig] = None) -> PredictionPredictionProcessedData:
+    def process_for_prediction(
+        self, single_input: PredictionPredictionRawData, config: Optional[PredictionDataConfig] = None
+    ) -> PredictionPredictionProcessedData:
         """
         Processes a single movie's data for prediction.
 
@@ -260,8 +304,9 @@ class PredictionDataProcessor(
         return x_scaled, y_scaled
 
     @override
-    def _prepare_for_split(self, raw_data: PredictionTrainingRawData, config: PredictionDataConfig) -> tuple[
-        NDArray[float32], NDArray[float64]]:
+    def _prepare_for_split(
+        self, raw_data: PredictionTrainingRawData, config: PredictionDataConfig
+    ) -> tuple[NDArray[float32], NDArray[float64]]:
         """
         Creates time-series sequences (x and y) from raw movie data.
 
@@ -280,8 +325,9 @@ class PredictionDataProcessor(
         return x, y
 
     @override
-    def _post_process_splits(self, split_data: SplitDataset[NDArray[float32], NDArray[float64]],
-                             config: PredictionDataConfig) -> PredictionTrainingProcessedData:
+    def _post_process_splits(
+        self, split_data: SplitDataset[NDArray[float32], NDArray[float64]], config: PredictionDataConfig
+    ) -> PredictionTrainingProcessedData:
         """
         Fits the scaler on the training data and applies it to all data splits.
 
@@ -292,8 +338,9 @@ class PredictionDataProcessor(
         return self._scale_data(unscaled_data=split_data)
 
     @staticmethod
-    def _create_xy_from_sessions(sessions: list[MovieSessionData], week_limit: int) \
-        -> tuple[NDArray[float32], NDArray[float64]]:
+    def _create_xy_from_sessions(
+        sessions: list[MovieSessionData], week_limit: int
+    ) -> tuple[NDArray[float32], NDArray[float64]]:
         """
         Creates input sequences (x) and target values (y) from a list of MovieSessionData.
 
@@ -350,7 +397,8 @@ class PredictionDataProcessor(
         """
 
         return list(
-            map(lambda week: PredictionDataProcessor._extract_features_from_week(week=week).as_numerical_list(), weeks))
+            map(lambda week: PredictionDataProcessor._extract_features_from_week(week=week).as_numerical_list(), weeks)
+        )
 
     def _scale_feature_in_sequences(self, sequences: NDArray[float32]) -> NDArray[float32]:
         """
@@ -379,8 +427,9 @@ class PredictionDataProcessor(
 
         return scaled_sequences
 
-    def _scale_data(self, unscaled_data: SplitDataset[NDArray[float32], NDArray[float64]]) \
-        -> PredictionTrainingProcessedData:
+    def _scale_data(
+        self, unscaled_data: SplitDataset[NDArray[float32], NDArray[float64]]
+    ) -> PredictionTrainingProcessedData:
         """
         Fits a scaler on the training data and applies it to all data splits.
 

--- a/src/utilities/decorators.py
+++ b/src/utilities/decorators.py
@@ -1,0 +1,41 @@
+from functools import wraps
+from typing import Any, Type, TypeVar
+
+T = TypeVar('T')
+
+
+def frozen_after_init(cls: Type[T]) -> Type[T]:
+    """
+    Decorates a class to enforce immutability after initialization.
+
+    Wraps the ``__init__`` method to automatically call ``_lock()`` upon completion.
+    The decorated class must implement ``_lock()`` and ``__setattr__`` to handle
+    the locking logic.
+
+    :param cls: The class to be decorated.
+    :return: The decorated class with the modified ``__init__``.
+    """
+    original_init = cls.__init__
+
+    @wraps(original_init)
+    def new_init(self, *args: Any, **kwargs: Any):
+        """
+        Initializes the instance and locks it.
+
+        Calls the original ``__init__`` and then triggers the ``_lock`` method.
+
+        :param self: The instance being initialized.
+        :param args: Positional arguments passed to the original ``__init__``.
+        :param kwargs: Keyword arguments passed to the original ``__init__``.
+        :raises TypeError: If the instance does not have a callable ``_lock`` method.
+        """
+        original_init(self, *args, **kwargs)
+
+        if hasattr(self, '_lock') and callable(getattr(self, '_lock')):
+            getattr(self, '_lock')()
+        else:
+            raise TypeError(f"Class {cls.__name__} decorated with @frozen_after_init must implement a _lock() method.")
+
+    cls.__init__ = new_init
+
+    return cls


### PR DESCRIPTION
## Problem
This PR addresses two technical debt items identified in #47:

1.  **Lack of Architectural Type Safety**: The `BaseModelHandler._prepare_training_config` method previously returned a raw `dict[str, any]`. This forced subclasses (e.g., `PredictionModelHandler`) to manually cast the configuration dictionary to a specific type, treating type safety as an implementation detail rather than an architectural contract.
2.  **Unnecessary Parameters in Prediction Mode**: The `PredictionDataConfig` dataclass strictly required `split_ratios` and `random_state`. These fields are essential for training but irrelevant during inference (prediction), forcing the `predict` command to pass dummy values.

## Proposed Solution
We refactored the handler hierarchy to be generic over the configuration dictionary type and relaxed the constraints on the data configuration dataclass.

### Key Changes
*   **Generic Handler Architecture**:
    *   Updated `BaseModelHandler` to `BaseModelHandler(Generic[ConfigDictType])`.
    *   Propagated this generic type through `GradientModelHandler` and `RegressionModelHandler`.
    *   `PredictionModelHandler` now inherits from `RegressionModelHandler[PredictionConfigDict]`, allowing static analysis tools to infer the correct configuration type automatically.
*   **Data Configuration Cleanup**:
    *   Modified `PredictionDataConfig` in `src/models/prediction/components/data_processor.py`. The `split_ratios` and `random_state` fields are now `Optional` (defaulting to `None`).
    *   Removed dummy value injection in `PredictionModelHandler.predict`.

## Impact
*   **Type Safety**: Eliminates the need for `cast()` calls in subclass `train` methods regarding configuration objects.
*   **Code Clarity**: The `PredictionDataConfig` structure now accurately reflects that training parameters are not required for prediction tasks.

Closes #47