### PR TITLE
Fix Nginx startup crash and sanitize global configuration

### DIFF
--- a/environments/website/Dockerfile
+++ b/environments/website/Dockerfile
@@ -4,8 +4,10 @@ LABEL maintainer="Iorimiya <iorimiya.vina@gmail.com>"
 LABEL version="1.1.0"
 LABEL description="Movie Box Office Predictor Website Node"
 
+# 安裝必要工具以授予特權連接埠權限
 RUN apk add --no-cache libcap
 
+# 建立與其他節點一致的非 root 使用者
 ARG USERNAME=user
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -15,15 +17,19 @@ RUN addgroup -g $USER_GID $USERNAME \
 
 RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx
 
+
+RUN sed -i '/^user /d' /etc/nginx/nginx.conf \
+    && sed -i '/^pid /d' /etc/nginx/nginx.conf \
+    && sed -i '1s/^/pid \/tmp\/nginx.pid;\n/' /etc/nginx/nginx.conf
+
+
 RUN touch /var/run/nginx.pid \
     && chown -R $USERNAME:$USER_GID /var/cache/nginx /var/log/nginx /etc/nginx /usr/share/nginx/html /var/run/nginx.pid
 
-RUN sed -i '1s/^/pid \/tmp\/nginx.pid;\n/' /etc/nginx/nginx.conf
-
 RUN rm /etc/nginx/conf.d/default.conf
-
 COPY --chown=$USERNAME:$USER_GID ./nginx/default.conf /etc/nginx/conf.d/default.conf
 
+# 切換身分
 USER $USERNAME
 
 EXPOSE 80


### PR DESCRIPTION
### Summary
This PR fixes a critical configuration conflict in the website node that prevented the Nginx service from starting. It sanitizes the global `nginx.conf` to align with unprivileged execution requirements.

### Changes
- **Configuration Sanitization**: Added `sed` commands to explicitly remove default `user` and `pid` directives from `/etc/nginx/nginx.conf`.
- **PID Management**: Re-implemented the injection of `pid /tmp/nginx.pid;` to ensure it is the sole PID directive in the configuration.
- **Log Cleanup**: Removed the redundant `user nginx;` directive to eliminate startup warnings when running as an unprivileged user.

### Motivation
In the official Nginx Alpine image, `/etc/nginx/nginx.conf` contains hardcoded defaults. Simply prepending a new PID path creates a duplicate entry, which Nginx's parser rejects. This fix ensures the configuration is valid for non-root execution.

### Testing
- Successfully built the image and verified the service remains in "Running" state.
- Inspected `/etc/nginx/nginx.conf` inside the container to confirm no duplicate directives exist.
- Verified that Nginx logs no longer contain `[emerg]` or `[warn]` related to user privileges.