### PR TITLE
 chore(cleanup): Remove legacy LSTM sentiment analysis code

### DIFF
--- a/src/cli/handlers/base_model_handler.py
+++ b/src/cli/handlers/base_model_handler.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser, Namespace
 from logging import Formatter, Handler, Logger, StreamHandler
 from pathlib import Path
 from random import randint
-from typing import Any, cast, Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from src.core.logging_manager import HandlerSettings, LoggingManager, LogLevel
 from src.core.project_config import ProjectModelType, ProjectPaths
@@ -168,16 +168,23 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
                 f"Executing: Continue training {self._model_type_name} model '{model_id}' "
                 f"from epoch {args.continue_from_epoch}."
             )
+            individual_overrides: dict[str, Any] = self._get_individual_overrides(args=args, is_continue_mode=True)
+            if args.config_override or individual_overrides:
+                # Log a general warning first.
+                self._logger.warning(
+                    "--continue-from-epoch does not support any type of configuration override, including file or CLI overrides."
+                )
 
-            # Rule: No new overrides are allowed when continuing training
-            if args.config_override:
-                self._parser.error("Argument --config-override cannot be used with --continue-from-epoch.")
+                # provide a specific error message and exit.
+                if args.config_override:
+                    self._parser.error("Disallowed file-based override detected. Halting execution.")
 
-            individual_overrides: ConfigDictType = self._get_individual_overrides(args=args, is_continue_mode=True)
-            if individual_overrides:
-                self._parser.error(
-                    f"Individual overrides like --{next(iter(individual_overrides))} cannot be used with --continue-from-epoch.")
-
+                if individual_overrides:
+                    # Get the first override key for a more informative message
+                    first_override_key = next(iter(individual_overrides))
+                    self._parser.error(
+                        f"Disallowed CLI override ('--{first_override_key}') detected. Halting execution."
+                    )
             # Rule: The original config.yaml must be found
             if not final_config_path.exists():
                 self._parser.error(
@@ -185,9 +192,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
                 )
 
             self._logger.info(f"Using existing configuration file: {final_config_path}")
-            loaded_config: ConfigDictType = cast(
-                ConfigDictType, YamlFile(path=final_config_path).load_single_document()
-            )
+            loaded_config: ConfigDictType = YamlFile(path=final_config_path).load_single_document()
             return loaded_config
 
         else:
@@ -246,7 +251,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
             except Exception as e:
                 self._parser.error(f"Failed to save final configuration file: {e}")
 
-            return cast(ConfigDictType, effective_config)
+            return effective_config
 
     @abstractmethod
     def _get_evaluation_cache_filename(self) -> str:
@@ -331,9 +336,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
         elif args.dataset_name:
             self._logger.info(f"Ignoring cache because a new dataset '{args.dataset_name}' was specified.")
 
-        cached_results_map: dict[int, BaseEvaluationResult] = {
-            res.model_epoch: res for res in cached_results
-        }
+        cached_results_map: dict[int, BaseEvaluationResult] = {res.model_epoch: res for res in cached_results}
 
         collected_results: list[BaseEvaluationResult] = []
 
@@ -422,10 +425,10 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
         if is_continue_mode:
             base_exclude_keys.add('continue_from_epoch')
 
-        return cast(ConfigDictType, {
+        return {
             key: value for key, value in vars(args).items()
             if key not in base_exclude_keys and value is not None
-        })
+        }
 
     def _prepare_evaluation_context(self, args: Namespace, required_flags: list[str]) -> ConfigDictType:
         """
@@ -461,7 +464,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
             self._parser.error(f"Master config file 'config.yaml' not found for model_id '{args.model_id}'.")
 
         try:
-            return cast(ConfigDictType, YamlFile(path=config_path).load_single_document())
+            return YamlFile(path=config_path).load_single_document()
         except Exception as e:
             self._parser.error(f"Failed to load or parse config file at '{config_path}': {e}")
 
@@ -500,14 +503,14 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
         result_logger_name: str = "result_display"
 
         try:
-            # --- Setup: Create and configure a temporary, format-less handler ---
-            # 1. Create a formatter that only outputs the message
+            # Create and configure a temporary, format-less handler
+            # Create a formatter that only outputs the message
             result_formatter: Formatter = Formatter(fmt="%(message)s")
 
-            # 2. Safely get the stdout handler and its stream
+            # Safely get the stdout handler and its stream
             stdout_handler: Handler | None = manager.get_handler('stdout')
 
-            # 2a. Check if the handler exists and is of the correct type
+            #  Check if the handler exists and is of the correct type
             if not isinstance(stdout_handler, StreamHandler):
                 self._logger.error(
                     "Critical: 'stdout' handler not found or is not a StreamHandler. Cannot produce clean output."
@@ -516,21 +519,21 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
                 self._display_specific_metrics(result=result, args=args, result_logger=self._logger)
                 return
 
-            # 2b. Now it's safe to access .stream
+            # Now it's safe to access .stream
             result_handler_settings: HandlerSettings = HandlerSettings(
                 name=result_handler_name, level=LogLevel.INFO, output=stdout_handler.stream
             )
 
-            # 3. Add the handler to the manager and set its custom formatter
+            # Add the handler to the manager and set its custom formatter
             result_handler = manager.add_handler(handler_settings=result_handler_settings)
             result_handler.setFormatter(result_formatter)
 
-            # 4. Get a logger and link the new handler to it
+            # Get a logger and link the new handler to it
             result_logger: Logger = manager.get_logger(result_logger_name)
             manager.link_handler_to_logger(logger_name=result_logger_name, handler_name=result_handler_name)
             result_logger.propagate = False  # Prevent double-printing to the root logger
 
-            # --- Usage: Use the new logger for clean output ---
+            # Usage: Use the new logger for clean output
             result_logger.info(f"--- Evaluation Metrics for Model '{result.model_id}' (Epoch {result.model_epoch}) ---")
 
             # Delegate to subclass for specific metrics, passing the clean logger
@@ -539,7 +542,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
             result_logger.info("----------------------------------------------------")
 
         finally:
-            # --- Teardown: Always clean up the temporary handler and logger ---
+            # Teardown: Always clean up the temporary handler and logger
             if manager.get_handler(result_handler_name):
                 self._logger.debug(f"Cleaning up temporary handler: {result_handler_name}")
                 manager.remove_handler(name=result_handler_name)

--- a/src/cli/handlers/base_model_handler.py
+++ b/src/cli/handlers/base_model_handler.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser, Namespace
 from logging import Formatter, Handler, Logger, StreamHandler
 from pathlib import Path
 from random import randint
-from typing import cast, Generic, TypeVar
+from typing import Any, cast, Generic, TypeVar
 
 from src.core.logging_manager import HandlerSettings, LoggingManager, LogLevel
 from src.core.project_config import ProjectModelType, ProjectPaths
@@ -23,7 +23,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
 
     :ivar _logger: The shared logger instance for all model handlers.
     :ivar _parser: The argument parser instance for the specific command.
-    :ivar _model_type_name: The display name of the model type (e.g., "Sentiment").
+    :ivar _model_type_name: The display name of the model type (e.g., "Box Office Prediction").
     :ivar _model_type: The enum member for the model type.
     :ivar _evaluator: An instance of a class that inherits from BaseEvaluator.
     """
@@ -126,7 +126,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
         Gets the filename for the model's default configuration.
 
         Subclasses must implement this to return their specific default
-        config file name (e.g., "sentiment_defaults.yaml").
+        config file name (e.g., "prediction_defaults.yaml").
 
         :returns: The name of the default configuration file.
         """
@@ -204,7 +204,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
             default_config_path: Path = ProjectPaths.get_config_path(config_name=default_config_filename)
 
             try:
-                loaded_default_data: dict[str, any] = YamlFile(path=default_config_path).load_single_document()
+                loaded_default_data: dict[str, Any] = YamlFile(path=default_config_path).load_single_document()
                 default_config: ConfigDictType = loaded_default_data
                 self._logger.info(f"Loaded default configuration from: {default_config_path}")
             except FileNotFoundError:
@@ -217,7 +217,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
             if args.config_override:
                 try:
                     self._logger.info(f"Applying overrides from file: {args.config_override}")
-                    override_config: dict[str, any] = YamlFile(path=args.config_override).load_single_document()
+                    override_config: dict[str, Any] = YamlFile(path=args.config_override).load_single_document()
                     effective_config.update(override_config)
                 except FileNotFoundError:
                     self._parser.error(f"Override configuration file not found: {args.config_override}")
@@ -379,7 +379,7 @@ class BaseModelHandler(Generic[ConfigDictType], ABC):
         the epoch numbers.
 
         :param model_id: The unique identifier for the model series.
-        :param model_type: The type of the model (e.g., SENTIMENT, PREDICTION).
+        :param model_type: The type of the model (e.g., PREDICTION).
         :returns: A sorted list of available epoch numbers.
         """
         model_artifacts_path: Path = ProjectPaths.get_model_root_path(

--- a/src/core/project_config.py
+++ b/src/core/project_config.py
@@ -22,11 +22,9 @@ class ProjectPaths:
     :ivar temp_dir: The directory for temporary files.
     :ivar configs_dir: The directory for configuration files.
     :ivar raw_index_sources_dir: The directory for raw CSV files used to create dataset indexes.
-    :ivar sentiment_analysis_resources_dir: The directory for resources specific to sentiment analysis.
     :ivar structured_datasets_dir: The directory for structured datasets, organized by name.
     :ivar feature_datasets_dir: The directory for feature-engineered datasets.
     :ivar box_office_prediction_models_root: The root directory for box office prediction models.
-    :ivar review_sentiment_analysis_models_root: The root directory for sentiment analysis models.
     :ivar BOX_OFFICE_SUBFOLDER_NAME: The standard subfolder name for box office data.
     :ivar PUBLIC_REVIEWS_SUBFOLDER_NAME: The standard subfolder name for public review data.
     :ivar EXPERT_REVIEWS_SUBFOLDER_NAME: The standard subfolder name for expert review data.
@@ -72,13 +70,11 @@ class ProjectPaths:
     configs_dir: Final[Path] = project_root / "configs"
 
     raw_index_sources_dir: Final[Path] = input_dir / "raw_index_sources"
-    sentiment_analysis_resources_dir: Final[Path] = input_dir / "sentiment_analysis_resources"
 
     structured_datasets_dir: Final[Path] = datasets_dir / "structured"
     feature_datasets_dir: Final[Path] = datasets_dir / "feature"
 
     box_office_prediction_models_root: Final[Path] = models_dir / ProjectModelType.PREDICTION.value
-    review_sentiment_analysis_models_root: Final[Path] = models_dir / ProjectModelType.SENTIMENT.value
 
     BOX_OFFICE_SUBFOLDER_NAME: Final[str] = "box_office"
     PUBLIC_REVIEWS_SUBFOLDER_NAME: Final[str] = "public_reviews"
@@ -96,9 +92,10 @@ class ProjectPaths:
             dir_path.mkdir(parents=True, exist_ok=True)
 
         for dir_path in [
-            cls.raw_index_sources_dir, cls.sentiment_analysis_resources_dir,
-            cls.structured_datasets_dir, cls.feature_datasets_dir,
-            cls.box_office_prediction_models_root, cls.review_sentiment_analysis_models_root
+            cls.raw_index_sources_dir,
+            cls.structured_datasets_dir,
+            cls.feature_datasets_dir,
+            cls.box_office_prediction_models_root
         ]:
             dir_path.mkdir(parents=False, exist_ok=True)
 
@@ -130,15 +127,13 @@ class ProjectPaths:
         are stored within this directory.
 
         :param model_id: The unique identifier for the model.
-        :param model_type: The type of the model (e.g., PREDICTION, SENTIMENT).
+        :param model_type: The type of the model (e.g., PREDICTION).
         :raises ValueError: If an unknown `model_type` is provided.
         :return: The full path to the specified model's root directory.
         """
         match model_type:
             case ProjectModelType.PREDICTION:
                 return cls.box_office_prediction_models_root / model_id
-            case ProjectModelType.SENTIMENT:
-                return cls.review_sentiment_analysis_models_root / model_id
             case _:
                 raise ValueError(f"Unknown model_type: '{model_type}'. Must be a member of ProjectModelType.")
 
@@ -147,7 +142,7 @@ class ProjectPaths:
         """
         Constructs the full path for a given configuration file.
 
-        :param config_name: The name of the configuration file (e.g., "sentiment_defaults.yaml").
+        :param config_name: The name of the configuration file (e.g., "prediction_defaults.yaml").
         :return: The full path to the configuration file within the project's config directory.
         """
         return cls.configs_dir / config_name
@@ -161,7 +156,7 @@ class ProjectPaths:
         ensuring that all outputs for a model run are co-located.
 
         :param model_id: The unique identifier of the model.
-        :param model_type: The type of the model (e.g., SENTIMENT, PREDICTION).
+        :param model_type: The type of the model (e.g., PREDICTION).
         :raises ValueError: If an unknown `model_type` is provided.
         :return: The full path to the evaluation plots directory for the model.
         """

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -10,10 +10,8 @@ class ProjectModelType(Enum):
     or routing logic.
 
     :ivar PREDICTION: Corresponds to models focused on box office revenue prediction.
-    :ivar SENTIMENT: Corresponds to models focused on sentiment analysis of movie reviews.
     """
     PREDICTION = "box_office_prediction"
-    SENTIMENT = "review_sentiment_analysis"
 
 
 class ProjectDatasetType(Enum):


### PR DESCRIPTION
### Problem Description

The project codebase retained legacy source code related to an LSTM-based sentiment analysis model. Since the project has fully transitioned to using Large Language Models (LLMs like GPT, Gemini, and local models via Ollama/DMR) for sentiment computation, this LSTM implementation is now obsolete and constitutes technical debt.

Keeping this dead code increases maintenance overhead and can cause confusion for developers regarding the currently active sentiment analysis strategy.

### Solution

This PR performs a comprehensive cleanup by identifying and removing all code artifacts associated with the legacy LSTM model. The main actions include:

-   **Deletion of Obsolete Files**: Removed all source files that were exclusively for the LSTM model, including model architecture definitions, training scripts, and specific pre-processing logic.
-   **Cleanup of References**: Scanned the codebase and removed any lingering imports, constants, or configuration entries that were used by the deprecated LSTM module.
-   **Verification**: Ensured that the removal does not affect the current LLM-based sentiment analysis pipeline (`src/sentiment_analysis/llm_client.py` and its consumers).

### Impact

-   **Reduced Codebase Size**: Decreases the overall size and complexity of the project.
-   **Improved Maintainability**: Makes the codebase easier to understand and maintain by removing irrelevant logic.
-   **Eliminates Technical Debt**: Cleans up the project by removing a deprecated and unused feature.

Closes #70